### PR TITLE
specs-qemu/mips/musl: MIPS Musl spec files

### DIFF
--- a/releases/specs-qemu/mips/musl/stage1-mipsel3-o32-musl-openrc.spec
+++ b/releases/specs-qemu/mips/musl/stage1-mipsel3-o32-musl-openrc.spec
@@ -1,0 +1,15 @@
+subarch: mipsel3
+target: stage1
+version_stamp: musl-openrc-@TIMESTAMP@
+interpreter: /usr/bin/qemu-mipsel
+rel_type: default
+profile: default/linux/mips/17.0/musl/mipsel/o32
+snapshot: @TIMESTAMP@
+source_subpath: musl/stage3-mipsel3-musl-@TIMESTAmP@
+compression_mode: pixz
+decompressor_search_order: xz bzip2
+update_seed: yes
+update_seed_command: -uDN @world
+chost: mipsel-unknown-linux-musl
+portage_confdir: @REPO_DIR@/releases/portage/stages-qemu
+portage_prefix: releng

--- a/releases/specs-qemu/mips/musl/stage3-mipsel3-o32-musl-openrc.spec
+++ b/releases/specs-qemu/mips/musl/stage3-mipsel3-o32-musl-openrc.spec
@@ -1,0 +1,12 @@
+subarch: mipsel3
+target: stage3
+version_stamp: musl-openrc-@TIMESTAMP@
+interpreter: /usr/bin/qemu-mipsel
+rel_type: default
+profile: default/linux/mips/17.0/musl/mipsel/o32
+snapshot: @TIMESTAMP@
+source_subpath: default/stage1-mipsel3-musl-openrc-@TIMESTAMP@
+compression_mode: pixz
+decompressor_search_order: xz bzip2
+portage_confdir: @REPO_DIR@/releases/portage/stages-qemu
+portage_prefix: releng


### PR DESCRIPTION
These are my working spec files for building musl on a mipsel3 based system, so far currently tested on a PlayStation 2.

If you require a seed tarball then I have one at http://www.immolo.co.uk/stage3-mipsel3-musl-openrc-20221015.tar.xz which will save the hassle of getting a working system in crossdev beforehand.

Currently this seems like the only mips cpu musl works on in Gentoo but if there is a need then I am willing to test what others will work when the new profile update drops.

Signed-off-by: Ian Jordan <immoloism@gmail.com>