### PR TITLE
specs/{amd64,x86}: add genfstab and arch-chroot to isos

### DIFF
--- a/releases/specs/amd64/hardened/admincd-stage1.spec
+++ b/releases/specs/amd64/hardened/admincd-stage1.spec
@@ -180,6 +180,7 @@ livecd/packages:
 	sys-fs/exfat-utils
 	sys-fs/extundelete
 	sys-fs/f2fs-tools
+	sys-fs/genfstab
 	sys-fs/jfsutils
 	sys-fs/lsscsi
 	sys-fs/lvm2

--- a/releases/specs/amd64/hardened/admincd-stage1.spec
+++ b/releases/specs/amd64/hardened/admincd-stage1.spec
@@ -116,6 +116,7 @@ livecd/packages:
 	net-wireless/iw
 	net-wireless/wireless-tools
 	net-wireless/wpa_supplicant
+	sys-apps/arch-chroot
 	sys-apps/arrayprobe
 	sys-apps/acl
 	sys-apps/attr

--- a/releases/specs/amd64/installcd-stage1.spec
+++ b/releases/specs/amd64/installcd-stage1.spec
@@ -84,6 +84,7 @@ livecd/packages:
 	sys-fs/dosfstools
 	sys-fs/e2fsprogs
 	sys-fs/f2fs-tools
+	sys-fs/genfstab
 	sys-fs/jfsutils
 	sys-fs/lsscsi
 	sys-fs/lvm2

--- a/releases/specs/amd64/installcd-stage1.spec
+++ b/releases/specs/amd64/installcd-stage1.spec
@@ -57,6 +57,7 @@ livecd/packages:
 	net-wireless/iw
 	net-wireless/wireless-tools
 	net-wireless/wpa_supplicant
+	sys-apps/arch-chroot
 	sys-apps/busybox
 	sys-apps/dmidecode
 	sys-apps/ethtool

--- a/releases/specs/amd64/livegui/livegui-stage1.spec
+++ b/releases/specs/amd64/livegui/livegui-stage1.spec
@@ -175,6 +175,7 @@ livecd/packages:
 	net-wireless/iw
 	net-wireless/wireless-tools
 	net-wireless/wpa_supplicant
+	sys-apps/arch-chroot
 	sys-apps/arrayprobe
 	sys-apps/acl
 	sys-apps/attr

--- a/releases/specs/amd64/livegui/livegui-stage1.spec
+++ b/releases/specs/amd64/livegui/livegui-stage1.spec
@@ -241,6 +241,7 @@ livecd/packages:
 	sys-fs/extundelete
 	sys-fs/fuse-exfat
 	sys-fs/f2fs-tools
+	sys-fs/genfstab
 	sys-fs/growpart
 	sys-fs/jfsutils
 	sys-fs/lsscsi

--- a/releases/specs/x86/hardened/admincd-stage1-openrc.spec
+++ b/releases/specs/x86/hardened/admincd-stage1-openrc.spec
@@ -117,6 +117,7 @@ livecd/packages:
 	net-wireless/iw
 	net-wireless/wireless-tools
 	net-wireless/wpa_supplicant
+	sys-apps/arch-chroot
 	sys-apps/arrayprobe
 	sys-apps/acl
 	sys-apps/attr

--- a/releases/specs/x86/hardened/admincd-stage1-openrc.spec
+++ b/releases/specs/x86/hardened/admincd-stage1-openrc.spec
@@ -179,6 +179,7 @@ livecd/packages:
 	sys-fs/exfat-utils
 	sys-fs/extundelete
 	sys-fs/f2fs-tools
+	sys-fs/genfstab
 	sys-fs/jfsutils
 	sys-fs/lsscsi
 	sys-fs/lvm2

--- a/releases/specs/x86/i486/installcd-stage1-openrc.spec
+++ b/releases/specs/x86/i486/installcd-stage1-openrc.spec
@@ -59,6 +59,7 @@ livecd/packages:
 	net-wireless/iw
 	net-wireless/wireless-tools
 	net-wireless/wpa_supplicant
+	sys-apps/arch-chroot
 	sys-apps/busybox
 	sys-apps/dmidecode
 	sys-apps/ethtool

--- a/releases/specs/x86/i486/installcd-stage1-openrc.spec
+++ b/releases/specs/x86/i486/installcd-stage1-openrc.spec
@@ -83,6 +83,7 @@ livecd/packages:
 	sys-fs/dosfstools
 	sys-fs/e2fsprogs
 	sys-fs/f2fs-tools
+	sys-fs/genfstab
 	sys-fs/jfsutils
 	sys-fs/lsscsi
 	sys-fs/lvm2


### PR DESCRIPTION
New working ebuilds sys-apps/arch-chroot and sys-fs/genfstab are now in ::gentoo.