### PR TITLE
portage/isos: enable wps on wpa_supplicant

### DIFF
--- a/releases/portage/isos/package.use/wpa_supplicant
+++ b/releases/portage/isos/package.use/wpa_supplicant
@@ -1,1 +1,1 @@
-net-wireless/wpa_supplicant tkip
+net-wireless/wpa_supplicant tkip wps


### PR DESCRIPTION
As with TKIP, WPS is still in common usage. However, unlike TKIP, this is still a manufacturer pushed 'feature'. As users may not have a say in their network administrator's decisions, enable it.

Closes: https://bugs.gentoo.org/801262