### PR TITLE
specs/*: add sec-keys/openpgp-keys-gentoo-release to images

### DIFF
--- a/releases/specs/amd64/hardened/admincd-stage1.spec
+++ b/releases/specs/amd64/hardened/admincd-stage1.spec
@@ -115,6 +115,7 @@ livecd/packages:
 	net-wireless/iw
 	net-wireless/wireless-tools
 	net-wireless/wpa_supplicant
+	sec-keys/openpgp-keys-gentoo-release
 	sys-apps/arch-chroot
 	sys-apps/arrayprobe
 	sys-apps/acl

--- a/releases/specs/amd64/installcd-stage1.spec
+++ b/releases/specs/amd64/installcd-stage1.spec
@@ -57,6 +57,7 @@ livecd/packages:
 	net-wireless/iw
 	net-wireless/wireless-tools
 	net-wireless/wpa_supplicant
+	sec-keys/openpgp-keys-gentoo-release
 	sys-apps/arch-chroot
 	sys-apps/busybox
 	sys-apps/dmidecode

--- a/releases/specs/amd64/livegui/livegui-stage1.spec
+++ b/releases/specs/amd64/livegui/livegui-stage1.spec
@@ -168,6 +168,7 @@ livecd/packages:
 	net-wireless/iw
 	net-wireless/wireless-tools
 	net-wireless/wpa_supplicant
+	sec-keys/openpgp-keys-gentoo-release
 	sys-apps/arch-chroot
 	sys-apps/arrayprobe
 	sys-apps/acl

--- a/releases/specs/arm64/installcd-stage1.spec
+++ b/releases/specs/arm64/installcd-stage1.spec
@@ -60,6 +60,7 @@ livecd/packages:
 	net-wireless/iw
 	net-wireless/wireless-tools
 	net-wireless/wpa_supplicant
+	sec-keys/openpgp-keys-gentoo-release
 	sys-apps/busybox
 	sys-apps/dmidecode
 	sys-apps/ethtool

--- a/releases/specs/hppa/installcd-stage1.spec
+++ b/releases/specs/hppa/installcd-stage1.spec
@@ -37,6 +37,7 @@ livecd/packages:
 	net-misc/rdate
 	net-misc/vconfig
 	net-proxy/dante
+	sec-keys/openpgp-keys-gentoo-release
 	sys-apps/ethtool
 	sys-apps/hdparm
 	sys-apps/iproute2

--- a/releases/specs/ia64/installcd-stage1.spec
+++ b/releases/specs/ia64/installcd-stage1.spec
@@ -51,6 +51,7 @@ livecd/packages:
 #	net-wireless/wireless-tools
 #	net-wireless/wpa_supplicant
 #	net-wireless/zd1201-firmware
+	sec-keys/openpgp-keys-gentoo-release
 	sys-apps/busybox
 	sys-apps/ethtool
 	sys-apps/fxload

--- a/releases/specs/ppc/ppc32/installcd-stage1.spec
+++ b/releases/specs/ppc/ppc32/installcd-stage1.spec
@@ -45,6 +45,7 @@ livecd/packages:
 	net-misc/rsync
 	net-wireless/wireless-tools
 	net-wireless/wpa_supplicant
+	sec-keys/openpgp-keys-gentoo-release
 	sys-apps/busybox
 	sys-apps/ethtool
 	sys-apps/fxload

--- a/releases/specs/ppc/ppc64le/installcd-stage1.spec
+++ b/releases/specs/ppc/ppc64le/installcd-stage1.spec
@@ -57,6 +57,7 @@ livecd/packages:
 	net-wireless/iwd
 	net-wireless/wireless-tools
 	net-wireless/wpa_supplicant
+	sec-keys/openpgp-keys-gentoo-release
 	sys-apps/busybox
 	sys-apps/ethtool
 	sys-apps/fxload

--- a/releases/specs/sparc/sparc64/installcd-stage1.spec
+++ b/releases/specs/sparc/sparc64/installcd-stage1.spec
@@ -56,6 +56,7 @@ livecd/packages:
 #	net-wireless/iw
 #	net-wireless/wireless-tools
 #	net-wireless/wpa_supplicant
+	sec-keys/openpgp-keys-gentoo-release
 	sys-apps/busybox
 #	sys-apps/dmidecode
 	sys-apps/ethtool

--- a/releases/specs/x86/hardened/admincd-stage1-openrc.spec
+++ b/releases/specs/x86/hardened/admincd-stage1-openrc.spec
@@ -116,6 +116,7 @@ livecd/packages:
 	net-wireless/iw
 	net-wireless/wireless-tools
 	net-wireless/wpa_supplicant
+	sec-keys/openpgp-keys-gentoo-release
 	sys-apps/arch-chroot
 	sys-apps/arrayprobe
 	sys-apps/acl

--- a/releases/specs/x86/i486/installcd-stage1-openrc.spec
+++ b/releases/specs/x86/i486/installcd-stage1-openrc.spec
@@ -59,6 +59,7 @@ livecd/packages:
 	net-wireless/iw
 	net-wireless/wireless-tools
 	net-wireless/wpa_supplicant
+	sec-keys/openpgp-keys-gentoo-release
 	sys-apps/arch-chroot
 	sys-apps/busybox
 	sys-apps/dmidecode


### PR DESCRIPTION
This makes it possible to follow the Gentoo Handbook.

See-Also: https://wiki.gentoo.org/wiki/Handbook:Parts/Installation/Media
Closes: https://bugs.gentoo.org/678614