### PR TITLE
Add sys-fs/xfsdump, enable thin-provisioning-tools again

### DIFF
--- a/releases/portage/isos-qemu/package.use/lvm
+++ b/releases/portage/isos-qemu/package.use/lvm
@@ -1,1 +1,2 @@
 */* lvm
+sys-fs/lvm2 thin

--- a/releases/portage/isos/package.use/lvm
+++ b/releases/portage/isos/package.use/lvm
@@ -1,1 +1,2 @@
 */* lvm
+sys-fs/lvm2 thin

--- a/releases/portage/livegui/package.use/lvm
+++ b/releases/portage/livegui/package.use/lvm
@@ -1,1 +1,2 @@
 */* lvm
+sys-fs/lvm2 thin

--- a/releases/specs-qemu/alpha/installcd-stage1.spec
+++ b/releases/specs-qemu/alpha/installcd-stage1.spec
@@ -57,6 +57,7 @@ livecd/packages:
 	sys-fs/lvm2
 	sys-fs/mdadm
 	sys-fs/reiserfsprogs
+	sys-fs/xfsdump
 	sys-fs/xfsprogs
 	sys-kernel/linux-firmware
 	sys-libs/gpm

--- a/releases/specs-qemu/hppa/installcd-stage1.spec
+++ b/releases/specs-qemu/hppa/installcd-stage1.spec
@@ -54,6 +54,7 @@ livecd/packages:
 	sys-fs/lvm2
 	sys-fs/mdadm
 	sys-fs/reiserfsprogs
+	sys-fs/xfsdump
 	sys-fs/xfsprogs
 	sys-libs/gpm
 	www-client/links

--- a/releases/specs/amd64/hardened/admincd-stage1.spec
+++ b/releases/specs/amd64/hardened/admincd-stage1.spec
@@ -191,6 +191,7 @@ livecd/packages:
 	sys-fs/ncdu
 	sys-fs/ntfs3g
 	sys-fs/reiserfsprogs
+	sys-fs/xfsdump
 	sys-fs/xfsprogs
 	sys-kernel/linux-firmware
 	sys-libs/gpm

--- a/releases/specs/amd64/installcd-stage1.spec
+++ b/releases/specs/amd64/installcd-stage1.spec
@@ -96,6 +96,7 @@ livecd/packages:
 	sys-fs/multipath-tools
 	sys-fs/ntfs3g
 	sys-fs/reiserfsprogs
+	sys-fs/xfsdump
 	sys-fs/xfsprogs
 	sys-kernel/linux-firmware
 	#force rebuild for USE="(-multilib*)"

--- a/releases/specs/amd64/livegui/livegui-stage1.spec
+++ b/releases/specs/amd64/livegui/livegui-stage1.spec
@@ -248,6 +248,7 @@ livecd/packages:
 	sys-fs/multipath-tools
 	sys-fs/ntfs3g
 	sys-fs/reiserfsprogs
+	sys-fs/xfsdump
 	sys-fs/xfsprogs
 	sys-kernel/linux-firmware
 	sys-libs/gpm

--- a/releases/specs/arm64/installcd-stage1.spec
+++ b/releases/specs/arm64/installcd-stage1.spec
@@ -95,6 +95,7 @@ livecd/packages:
 	sys-fs/multipath-tools
 	sys-fs/ntfs3g
 	sys-fs/reiserfsprogs
+	sys-fs/xfsdump
 	sys-fs/xfsprogs
 	sys-kernel/linux-firmware
 	sys-libs/gpm

--- a/releases/specs/hppa/installcd-stage1.spec
+++ b/releases/specs/hppa/installcd-stage1.spec
@@ -53,6 +53,7 @@ livecd/packages:
 	sys-fs/lvm2
 	sys-fs/mdadm
 	sys-fs/reiserfsprogs
+	sys-fs/xfsdump
 	sys-fs/xfsprogs
 	sys-libs/gpm
 	www-client/links

--- a/releases/specs/ia64/installcd-stage1.spec
+++ b/releases/specs/ia64/installcd-stage1.spec
@@ -48,6 +48,7 @@ livecd/packages:
 	sys-fs/jfsutils
 	sys-fs/mdadm
 	sys-fs/reiserfsprogs
+	sys-fs/xfsdump
 	sys-fs/xfsprogs
 	sys-libs/gpm
 	sys-power/acpid

--- a/releases/specs/ppc/ppc32/installcd-stage1.spec
+++ b/releases/specs/ppc/ppc32/installcd-stage1.spec
@@ -76,6 +76,7 @@ livecd/packages:
 	sys-fs/mdadm
 	sys-fs/ntfs3g
 	sys-fs/reiserfsprogs
+	sys-fs/xfsdump
 	sys-fs/xfsprogs
 	sys-libs/gpm
 	www-client/links

--- a/releases/specs/ppc/ppc64le/installcd-stage1.spec
+++ b/releases/specs/ppc/ppc64le/installcd-stage1.spec
@@ -96,6 +96,7 @@ livecd/packages:
 	sys-fs/reiserfsprogs
 	sys-fs/squashfs-tools
 	sys-fs/sysfsutils
+	sys-fs/xfsdump
 	sys-fs/xfsprogs
 	sys-kernel/linux-firmware
 	sys-libs/gpm

--- a/releases/specs/x86/hardened/admincd-stage1-openrc.spec
+++ b/releases/specs/x86/hardened/admincd-stage1-openrc.spec
@@ -190,6 +190,7 @@ livecd/packages:
 	sys-fs/ncdu
 	sys-fs/ntfs3g
 	sys-fs/reiserfsprogs
+	sys-fs/xfsdump
 	sys-fs/xfsprogs
 	sys-kernel/linux-firmware
 	sys-libs/gpm

--- a/releases/specs/x86/i486/installcd-stage1-openrc.spec
+++ b/releases/specs/x86/i486/installcd-stage1-openrc.spec
@@ -94,6 +94,7 @@ livecd/packages:
 	sys-fs/multipath-tools
 	sys-fs/ntfs3g
 	sys-fs/reiserfsprogs
+	sys-fs/xfsdump
 	sys-fs/xfsprogs
 	sys-kernel/linux-firmware
 	sys-libs/gpm


### PR DESCRIPTION
XFS is the FS we recommend in the handbook nowadays and xfsdump is a useful backup/admin tool.