### PR TITLE
releases: remove dev-lang/openssl-3.2 masks

### DIFF
--- a/releases/portage/isos-qemu/package.mask/releng/openssl
+++ b/releases/portage/isos-qemu/package.mask/releng/openssl
@@ -1,3 +1,0 @@
-# this version barfs on lots of minor arches, let's not try
-# to update to it
-=dev-libs/openssl-3.0.7-r1

--- a/releases/portage/isos/package.mask/releng/openssl
+++ b/releases/portage/isos/package.mask/releng/openssl
@@ -1,3 +1,0 @@
-# this version barfs on lots of minor arches, let's not try
-# to update to it
-=dev-libs/openssl-3.0.7-r1

--- a/releases/portage/livegui/package.mask/releng/openssl
+++ b/releases/portage/livegui/package.mask/releng/openssl
@@ -1,3 +1,0 @@
-# this version barfs on lots of minor arches, let's not try
-# to update to it
-=dev-libs/openssl-3.0.7-r1

--- a/releases/portage/stages-qemu/package.mask/releng/openssl
+++ b/releases/portage/stages-qemu/package.mask/releng/openssl
@@ -1,4 +1,0 @@
-# this version barfs on lots of minor arches, let's not try
-# to update to it
-=dev-libs/openssl-3.0.7-r1
-=dev-libs/openssl-3.2.1*

--- a/releases/portage/stages/package.mask/releng/openssl
+++ b/releases/portage/stages/package.mask/releng/openssl
@@ -1,4 +1,0 @@
-# this version barfs on lots of minor arches, let's not try
-# to update to it
-=dev-libs/openssl-3.0.7-r1
-=dev-libs/openssl-3.2.1*


### PR DESCRIPTION
And old specific version mask for 3.0.  Both relevant bugs fixed.

Bug: https://bugs.gentoo.org.923957
Bug: https://bugs.gentoo.org/923956