### PR TITLE
LiveGUI: AMD64 dist-kernel support

### DIFF
--- a/releases/portage/livegui/package.use/installkernel
+++ b/releases/portage/livegui/package.use/installkernel
@@ -1,0 +1,1 @@
+sys-kernel/installkernel dracut

--- a/releases/specs/amd64/livegui/livegui-stage1-genkernel.spec
+++ b/releases/specs/amd64/livegui/livegui-stage1-genkernel.spec
@@ -6,7 +6,7 @@ profile: default/linux/amd64/23.0/desktop/plasma
 snapshot_treeish: @TREEISH@
 source_subpath: 23.0-default/stage3-amd64-openrc-@TIMESTAMP@.tar.xz
 compression_mode: pixz
-portage_confdir: @REPODIR/releases/portage/livegui
+portage_confdir: @REPO_DIR@/releases/portage/livegui
 
 livecd/use:
 	-aac
@@ -248,12 +248,9 @@ livecd/packages:
 	sys-fs/mdadm
 	sys-fs/multipath-tools
 	sys-fs/ntfs3g
-	sys-fs/squashfs-tools
 	sys-fs/reiserfsprogs
 	sys-fs/xfsdump
 	sys-fs/xfsprogs
-	sys-kernel/dracut
-	sys-kernel/installkernel
 	sys-kernel/linux-firmware
 	sys-libs/gpm
 	sys-power/acpid

--- a/releases/specs/amd64/livegui/livegui-stage1.spec
+++ b/releases/specs/amd64/livegui/livegui-stage1.spec
@@ -6,7 +6,7 @@ profile: default/linux/amd64/23.0/desktop/plasma
 snapshot_treeish: @TREEISH@
 source_subpath: 23.0-default/stage3-amd64-openrc-@TIMESTAMP@.tar.xz
 compression_mode: pixz
-portage_confdir: @REPODIR/releases/portage/livegui
+portage_confdir: @REPO_DIR@/releases/portage/livegui
 
 livecd/use:
 	-aac

--- a/releases/specs/amd64/livegui/livegui-stage2-genkernel.spec
+++ b/releases/specs/amd64/livegui/livegui-stage2-genkernel.spec
@@ -1,0 +1,30 @@
+subarch: amd64
+version_stamp: plasma-@TIMESTAMP@
+target: livecd-stage2
+rel_type: 23.0-default
+profile: default/linux/amd64/23.0/desktop/plasma
+snapshot_treeish: @TREEISH@
+source_subpath: 23.0-default/livecd-stage1-amd64-plasma-@TIMESTAMP@
+portage_confdir: @REPO_DIR@/releases/portage/livegui
+
+livecd/bootargs: overlayfs nodhcp secureconsole
+livecd/depclean: no
+livecd/fstype: squashfs
+livecd/iso: livegui-amd64-@TIMESTAMP@.iso
+livecd/type: gentoo-release-livecd
+livecd/volid: Gentoo amd64 LiveGUI @TIMESTAMP@
+
+livecd/fsscript: @REPO_DIR@/releases/specs/amd64/livegui/files/fsscript-stage2.sh
+livecd/rcadd: udev|sysinit udev-mount|sysinit acpid|default dbus|default gpm|default NetworkManager|default elogind|boot
+livecd/unmerge: net-misc/netifrc
+
+livecd/empty:
+	/var/db/repos
+	/usr/src
+
+boot/kernel: gentoo
+
+boot/kernel/gentoo/sources: gentoo-sources
+boot/kernel/gentoo/config: @REPO_DIR@/releases/kconfig/amd64/livegui-amd64-5.15.23.config
+
+boot/kernel/gentoo/packages: --usepkg n zfs zfs-kmod broadcom-sta

--- a/releases/specs/amd64/livegui/livegui-stage2.spec
+++ b/releases/specs/amd64/livegui/livegui-stage2.spec
@@ -4,8 +4,8 @@ target: livecd-stage2
 rel_type: 23.0-default
 profile: default/linux/amd64/23.0/desktop/plasma
 snapshot_treeish: @TREEISH@
-source_subpath: default/livecd-stage1-amd64-plasma-@TIMESTAMP@
-portage_confdir: @REPODIR/releases/portage/livegui
+source_subpath: 23.0-default/livecd-stage1-amd64-plasma-@TIMESTAMP@
+portage_confdir: @REPO_DIR@/releases/portage/livegui
 
 livecd/bootargs: overlayfs nodhcp secureconsole cdroot
 livecd/depclean: no
@@ -14,7 +14,7 @@ livecd/iso: livegui-amd64-@TIMESTAMP@.iso
 livecd/type: gentoo-release-livecd
 livecd/volid: Gentoo amd64 LiveGUI @TIMESTAMP@
 
-livecd/fsscript: @REPODIR//releases/specs/amd64/livegui/files/fsscript-stage2.sh
+livecd/fsscript: @REPO_DIR@/releases/specs/amd64/livegui/files/fsscript-stage2.sh
 livecd/rcadd: udev|sysinit udev-mount|sysinit acpid|default dbus|default gpm|default NetworkManager|default elogind|boot display-manager|default
 livecd/unmerge: net-misc/netifrc
 

--- a/releases/specs/amd64/livegui/livegui-stage2.spec
+++ b/releases/specs/amd64/livegui/livegui-stage2.spec
@@ -4,18 +4,18 @@ target: livecd-stage2
 rel_type: 23.0-default
 profile: default/linux/amd64/23.0/desktop/plasma
 snapshot_treeish: @TREEISH@
-source_subpath: 23.0-default/livecd-stage1-amd64-plasma-@TIMESTAMP@
-portage_confdir: @REPO_DIR@/releases/portage/livegui
+source_subpath: default/livecd-stage1-amd64-plasma-@TIMESTAMP@
+portage_confdir: @REPODIR/releases/portage/livegui
 
-livecd/bootargs: overlayfs nodhcp secureconsole
+livecd/bootargs: overlayfs nodhcp secureconsole cdroot
 livecd/depclean: no
 livecd/fstype: squashfs
 livecd/iso: livegui-amd64-@TIMESTAMP@.iso
 livecd/type: gentoo-release-livecd
 livecd/volid: Gentoo amd64 LiveGUI @TIMESTAMP@
 
-livecd/fsscript: @REPO_DIR@/releases/specs/amd64/livegui/files/fsscript-stage2.sh
-livecd/rcadd: udev|sysinit udev-mount|sysinit acpid|default dbus|default gpm|default NetworkManager|default elogind|boot
+livecd/fsscript: @REPODIR//releases/specs/amd64/livegui/files/fsscript-stage2.sh
+livecd/rcadd: udev|sysinit udev-mount|sysinit acpid|default dbus|default gpm|default NetworkManager|default elogind|boot display-manager|default
 livecd/unmerge: net-misc/netifrc
 
 livecd/empty:
@@ -24,7 +24,5 @@ livecd/empty:
 
 boot/kernel: gentoo
 
-boot/kernel/gentoo/sources: gentoo-sources
-boot/kernel/gentoo/config: @REPO_DIR@/releases/kconfig/amd64/livegui-amd64-5.15.23.config
-
-boot/kernel/gentoo/packages: --usepkg n zfs zfs-kmod broadcom-sta
+boot/kernel/gentoo/distkernel: yes
+boot/kernel/gentoo/dracut_args: --xz --no-hostonly -a dmsquash-live -a mdraid -o btrfs -o crypt -o i18n -o usrmount -o lunmask -o qemu -o qemu-net -o nvdimm -o multipath -i /lib/keymaps /lib/keymaps -I busybox


### PR DESCRIPTION
Required change to remove the need for genkernel to boot the livegui.

This is currently tested as works for me so should have at least one person confirm it works before merging.