### PR TITLE
specs/amd64/livegui/files/fsscript-stage2.sh: Create /mnt/gentoo

### DIFF
--- a/releases/specs/amd64/livegui/files/fsscript-stage2.sh
+++ b/releases/specs/amd64/livegui/files/fsscript-stage2.sh
@@ -6,6 +6,9 @@ source /etc/profile
 env-update
 source /tmp/envscript
 
+# Create /mnt/gentoo
+mkdir /mnt/gentoo
+
 # No we don't want to run xdm...
 sed -e '/^DISPLAYMANAGER=/s/.*/DISPLAYMANAGER="sddm"/' -i /etc/conf.d/display-manager
 


### PR DESCRIPTION
Fix the lack of /mnt/gentoo being created on livegui.

Closes-bug: https://bugs.gentoo.org/915957