### PR TITLE
Add NetworkManager support to the livecd

### DIFF
--- a/releases/specs/amd64/installcd-stage1.spec
+++ b/releases/specs/amd64/installcd-stage1.spec
@@ -48,6 +48,7 @@ livecd/packages:
 	net-misc/dhcpcd
 	net-misc/iputils
 	net-misc/ndisc6
+	net-misc/networkmanager
 	net-misc/openssh
 	net-misc/rdate
 	net-misc/rsync

--- a/releases/specs/amd64/installcd-stage2-minimal.spec
+++ b/releases/specs/amd64/installcd-stage2-minimal.spec
@@ -7,11 +7,13 @@ snapshot_treeish: @TREEISH@
 source_subpath: 23.0-default/livecd-stage1-amd64-@TIMESTAMP@
 portage_confdir: @REPO_DIR@/releases/portage/isos
 
-livecd/bootargs: dokeymap
+livecd/bootargs: dokeymap nodhcp
 livecd/fstype: squashfs
 livecd/iso: install-amd64-minimal-@TIMESTAMP@.iso
 livecd/type: gentoo-release-minimal
 livecd/volid: Gentoo amd64 @TIMESTAMP@
+
+livecd/rcadd: NetworkManager|default
 
 boot/kernel: gentoo
 


### PR DESCRIPTION
A common user complaint is how bad the minimal cd handles WIFI so this change finally fixes that by switching to NetworkManager and in turn allowing users to have access to nmtui for easy network setup.

For now I've only added it to the amd64 livecd but once it's a had run across a good number of users then I'll add it to all live images and finally get the handbook team to update the outdated networking page we have.