### PR TITLE
arm64/installcd: Enable dist-kernel

### DIFF
--- a/releases/specs/arm64/installcd-stage1.spec
+++ b/releases/specs/arm64/installcd-stage1.spec
@@ -32,6 +32,7 @@ livecd/packages:
 	app-misc/screen
 	app-misc/tmux
 	app-portage/cpuid2cpuflags
+	app-portage/gentoolkit
 	app-portage/mirrorselect
 	app-shells/bash-completion
 	app-shells/gentoo-bashcomp

--- a/releases/specs/arm64/installcd-stage2-minimal.spec
+++ b/releases/specs/arm64/installcd-stage2-minimal.spec
@@ -14,7 +14,11 @@ livecd/iso: install-arm64-minimal-@TIMESTAMP@.iso
 livecd/type: gentoo-release-minimal
 livecd/volid: Gentoo arm64 @TIMESTAMP@
 
-boot/kernel: fallback
+boot/kernel: gentoo fallback
+
+boot/kernel/gentoo/distkernel: yes
+boot/kernel/gentoo/dracut_args: --xz --no-hostonly -a dmsquash-live -a mdraid -o btrfs -o crypt -o i18n -o usrmount -o lunmask -o qemu -o qemu-net -o nvdimm -o multipath -o zfs -i /lib/keymaps /lib/keymaps -I busybox
+boot/kernel/gentoo/packages: --usepkg n zfs zfs-kmod
 
 boot/kernel/fallback/sources: sys-kernel/gentoo-sources
 boot/kernel/fallback/config: @REPO_DIR@/releases/kconfig/arm64/arm64-5.15.12.config

--- a/releases/specs/arm64/installcd-stage2-minimal.spec
+++ b/releases/specs/arm64/installcd-stage2-minimal.spec
@@ -14,11 +14,11 @@ livecd/iso: install-arm64-minimal-@TIMESTAMP@.iso
 livecd/type: gentoo-release-minimal
 livecd/volid: Gentoo arm64 @TIMESTAMP@
 
-boot/kernel: gentoo
+boot/kernel: fallback
 
-boot/kernel/gentoo/sources: sys-kernel/gentoo-sources
-boot/kernel/gentoo/config: @REPO_DIR@/releases/kconfig/arm64/arm64-5.15.12.config
-boot/kernel/gentoo/packages: --usepkg n zfs zfs-kmod
+boot/kernel/fallback/sources: sys-kernel/gentoo-sources
+boot/kernel/fallback/config: @REPO_DIR@/releases/kconfig/arm64/arm64-5.15.12.config
+boot/kernel/fallback/packages: --usepkg n zfs zfs-kmod
 
 livecd/unmerge:
 	app-admin/eselect


### PR DESCRIPTION
Add dist-kernel support for arm64 installcd. 

Genkernel has been left as a fallback as this has only been tested in a VM for now. Will discuss removal of genkernel at a later date. 