### PR TITLE
livegui-stage2.spec: kmod fix

### DIFF
--- a/releases/portage/isos-x86/package.use/dist-kernel
+++ b/releases/portage/isos-x86/package.use/dist-kernel
@@ -1,0 +1,1 @@
+*/* dist-kernel

--- a/releases/portage/isos/package.use/dist-kernel
+++ b/releases/portage/isos/package.use/dist-kernel
@@ -1,0 +1,1 @@
+*/* dist-kernel

--- a/releases/portage/livegui/package.use/dist-kernel
+++ b/releases/portage/livegui/package.use/dist-kernel
@@ -1,0 +1,1 @@
+*/* dist-kernel

--- a/releases/specs/amd64/livegui/livegui-stage2.spec
+++ b/releases/specs/amd64/livegui/livegui-stage2.spec
@@ -12,7 +12,7 @@ livecd/depclean: no
 livecd/fstype: squashfs
 livecd/iso: livegui-amd64-@TIMESTAMP@.iso
 livecd/type: gentoo-release-livecd
-livecd/volid: gentoo-amd64-livegui 
+livecd/volid: gentoo-amd64-livegui
 
 livecd/fsscript: @REPO_DIR@/releases/specs/amd64/livegui/files/fsscript-stage2.sh
 livecd/rcadd: udev|sysinit udev-mount|sysinit acpid|default dbus|default gpm|default NetworkManager|default elogind|boot

--- a/releases/specs/amd64/livegui/livegui-stage2.spec
+++ b/releases/specs/amd64/livegui/livegui-stage2.spec
@@ -26,4 +26,4 @@ boot/kernel: gentoo
 
 boot/kernel/gentoo/distkernel: yes
 boot/kernel/gentoo/dracut_args: --xz --no-hostonly -a dmsquash-live -a mdraid -o btrfs -o crypt -o i18n -o usrmount -o lunmask -o qemu -o qemu-net -o nvdimm -o multipath -i /lib/keymaps /lib/keymaps -I busybox
-boot/kernel/gentoo/packages: --usepkg n zfs zfs-kmod
+boot/kernel/gentoo/packages: zfs zfs-kmod

--- a/releases/specs/amd64/livegui/livegui-stage2.spec
+++ b/releases/specs/amd64/livegui/livegui-stage2.spec
@@ -26,4 +26,4 @@ boot/kernel: gentoo
 
 boot/kernel/gentoo/distkernel: yes
 boot/kernel/gentoo/dracut_args: --xz --no-hostonly -a dmsquash-live -a mdraid -o btrfs -o crypt -o i18n -o usrmount -o lunmask -o qemu -o qemu-net -o nvdimm -o multipath -i /lib/keymaps /lib/keymaps -I busybox
-boot/kernel/gentoo/packages: sys-fs/zfs
+boot/kernel/gentoo/packages: --usepkg n zfs zfs-kmod

--- a/releases/specs/amd64/livegui/livegui-stage2.spec
+++ b/releases/specs/amd64/livegui/livegui-stage2.spec
@@ -26,4 +26,4 @@ boot/kernel: gentoo
 
 boot/kernel/gentoo/distkernel: yes
 boot/kernel/gentoo/dracut_args: --xz --no-hostonly -a dmsquash-live -a mdraid -o btrfs -o crypt -o i18n -o usrmount -o lunmask -o qemu -o qemu-net -o nvdimm -o multipath -i /lib/keymaps /lib/keymaps -I busybox
-boot/kernel/gentoo/packages: zfs zfs-kmod
+boot/kernel/gentoo/packages: zfs zfs-kmod broadcom-sta

--- a/releases/specs/arm64/installcd-stage2-minimal.spec
+++ b/releases/specs/arm64/installcd-stage2-minimal.spec
@@ -18,7 +18,7 @@ boot/kernel: gentoo
 
 boot/kernel/gentoo/sources: sys-kernel/gentoo-sources
 boot/kernel/gentoo/config: @REPO_DIR@/releases/kconfig/arm64/arm64-5.15.12.config
-boot/kernel/gentoo/packages: --usepkg n zfs zfs-kmod
+boot/kernel/gentoo/packages: zfs zfs-kmod
 
 livecd/unmerge:
 	app-admin/eselect

--- a/releases/specs/x86/hardened/admincd-stage2-openrc.spec
+++ b/releases/specs/x86/hardened/admincd-stage2-openrc.spec
@@ -19,7 +19,7 @@ boot/kernel/gentoo/distkernel: yes
 boot/kernel/gentoo/dracut_args: --xz --no-hostonly -a dmsquash-live -a mdraid -o btrfs -o crypt -o i18n -o usrmount -o lunmask -o qemu -o qemu-net -o nvdimm -o multipath -i /lib/keymaps /lib/keymaps -I busybox
 boot/kernel/gentoo/config: @REPO_DIR@/releases/kconfig/x86/dist-x86-livecd.config
 
-boot/kernel/gentoo/packages: --usepkg n broadcom-sta
+boot/kernel/gentoo/packages: broadcom-sta
 
 livecd/unmerge:
 	app-admin/eselect


### PR DESCRIPTION
This fixes the issue reported with zfs in live media but also changes how we manage this in releng to only rebuild binkgs when needed to save on build time.