### PR TITLE
Enable NetworkManager to installcds

### DIFF
--- a/releases/portage/isos-x86/package.use/wpa_supplicant
+++ b/releases/portage/isos-x86/package.use/wpa_supplicant
@@ -1,1 +1,1 @@
-net-wireless/wpa_supplicant tkip wps
+net-wireless/wpa_supplicant tkip wps dbus

--- a/releases/portage/isos/package.use/wpa_supplicant
+++ b/releases/portage/isos/package.use/wpa_supplicant
@@ -1,1 +1,1 @@
-net-wireless/wpa_supplicant tkip wps
+net-wireless/wpa_supplicant tkip wps dbus

--- a/releases/specs/amd64/hardened/admincd-stage1.spec
+++ b/releases/specs/amd64/hardened/admincd-stage1.spec
@@ -102,6 +102,7 @@ livecd/packages:
 	net-misc/dhcpcd
 	net-misc/iputils
 	net-misc/ndisc6
+	net-misc/networkmanager
 	net-misc/openssh
 	net-misc/rdate
 	net-misc/rsync

--- a/releases/specs/amd64/hardened/admincd-stage2.spec
+++ b/releases/specs/amd64/hardened/admincd-stage2.spec
@@ -13,6 +13,8 @@ livecd/iso: admincd-amd64-@TIMESTAMP@.iso
 livecd/type: gentoo-release-minimal
 livecd/volid: Gentoo-amd64-AdminCD-@DATESTAMP@
 
+livecd/rcadd: dbus|default NetworkManager|default
+
 boot/kernel: gentoo
 
 boot/kernel/gentoo/distkernel: yes

--- a/releases/specs/amd64/installcd-stage1.spec
+++ b/releases/specs/amd64/installcd-stage1.spec
@@ -49,6 +49,7 @@ livecd/packages:
 	net-misc/dhcpcd
 	net-misc/iputils
 	net-misc/ndisc6
+	net-misc/networkmanager
 	net-misc/openssh
 	net-misc/rdate
 	net-misc/rsync

--- a/releases/specs/amd64/installcd-stage2-minimal.spec
+++ b/releases/specs/amd64/installcd-stage2-minimal.spec
@@ -7,11 +7,13 @@ snapshot_treeish: @TREEISH@
 source_subpath: 23.0-default/livecd-stage1-amd64-@TIMESTAMP@
 portage_confdir: @REPO_DIR@/releases/portage/isos
 
-livecd/bootargs: dokeymap
+livecd/bootargs: dokeymap nodhcp
 livecd/fstype: squashfs
 livecd/iso: install-amd64-minimal-@TIMESTAMP@.iso
 livecd/type: gentoo-release-minimal
 livecd/volid: Gentoo-amd64-@DATESTAMP@
+
+livecd/rcadd: dbus|default NetworkManager|default
 
 boot/kernel: gentoo
 

--- a/releases/specs/arm64/installcd-stage1.spec
+++ b/releases/specs/arm64/installcd-stage1.spec
@@ -49,6 +49,7 @@ livecd/packages:
 	net-misc/chrony
 	net-misc/dhcpcd
 	net-misc/iputils
+	net-misc/networkmanager
 	net-misc/ndisc6
 	net-misc/openssh
 	net-misc/rdate

--- a/releases/specs/arm64/installcd-stage2-minimal.spec
+++ b/releases/specs/arm64/installcd-stage2-minimal.spec
@@ -7,12 +7,14 @@ snapshot_treeish: @TREEISH@
 source_subpath: 23.0-default/livecd-stage1-arm64-@TIMESTAMP@.tar.xz
 portage_confdir: @REPO_DIR@/releases/portage/isos
 
-livecd/bootargs: dokeymap
+livecd/bootargs: dokeymap nodhcp
 livecd/fstype: squashfs
 livecd/gk_mainargs: --all-ramdisk-modules --firmware
 livecd/iso: install-arm64-minimal-@TIMESTAMP@.iso
 livecd/type: gentoo-release-minimal
 livecd/volid: Gentoo arm64 @TIMESTAMP@
+
+livecd/rcadd: dbus|default NetworkManager|default
 
 boot/kernel: gentoo
 

--- a/releases/specs/x86/i486/installcd-stage1-openrc.spec
+++ b/releases/specs/x86/i486/installcd-stage1-openrc.spec
@@ -49,6 +49,7 @@ livecd/packages:
 	net-misc/dhcpcd
 	net-misc/iputils
 	net-misc/ndisc6
+	net-misc/networkmanager
 	net-misc/openssh
 	net-misc/rdate
 	net-misc/rsync

--- a/releases/specs/x86/i486/installcd-stage2-minimal-openrc.spec
+++ b/releases/specs/x86/i486/installcd-stage2-minimal-openrc.spec
@@ -14,6 +14,8 @@ livecd/iso: install-x86-minimal-@TIMESTAMP@.iso
 livecd/type: gentoo-release-minimal
 livecd/volid: Gentoo-x86-@DATESTAMP@
 
+livecd/rcadd: dbus|default NetworkManager|default
+
 boot/kernel: gentoo
 
 boot/kernel/gentoo/distkernel: yes


### PR DESCRIPTION
This PR enables NetworkManager on arm64, amd64 and x86 in preparation to redo the wireless section of the handbook and fix the longstanding complaint in Gentoo that WiFi is too hard.

Alpha and HPPA will follow once keywords and USE flags catch up (PR pending.) 