### PR TITLE
SELinux stages require +static-libs USE

### DIFF
--- a/releases/portage/stages/package.use/libsepol
+++ b/releases/portage/stages/package.use/libsepol
@@ -1,0 +1,2 @@
+# dependency required by "sys-libs/libselinux-3.7-r1
+sys-libs/libsepol static-libs


### PR DESCRIPTION
Since the stabliastion of sys-libs/libsepol we now require static-libs set on this package to allow building. Thanks to dwfreed on IRC for the pointers.