### PR TITLE
Fix keyboard layout switcher on LiveGUI

### DIFF
--- a/releases/specs/amd64/livegui/files/fsscript-stage2.sh
+++ b/releases/specs/amd64/livegui/files/fsscript-stage2.sh
@@ -66,7 +66,7 @@ Name=Keyboard settings
 Icon=preferences-system
 Type=Application
 SingleMainWindow=true
-Exec=systemsettings5 kcm_keyboard
+Exec=systemsettings kcm_keyboard
 Terminal=false
 " > .config/autostart/systemsettings-keyboard.desktop
 


### PR DESCRIPTION
Since KDE6 has become stable in Gentoo the layout switcher has no longer been autostarting in the LiveGUI. This commit corrects that.