### PR TITLE
[fix] resolve circular dependency between pam and elogind for desktop

### DIFF
--- a/releases/portage/stages-qemu/package.use/releng/circular
+++ b/releases/portage/stages-qemu/package.use/releng/circular
@@ -1,6 +1,7 @@
 # this makes only a difference for the "desktop" stages
 dev-db/sqlite -icu
 dev-lang/python -bluetooth
+sys-libs/pam -elogind
 
 # this is also needed for normal stage3
 net-misc/curl -http2 -http3 -quic -curl_quic_openssl

--- a/releases/portage/stages/package.use/releng/circular
+++ b/releases/portage/stages/package.use/releng/circular
@@ -1,6 +1,7 @@
 # this makes only a difference for the "desktop" stages
 dev-db/sqlite -icu
 dev-lang/python -bluetooth
+sys-libs/pam -elogind
 
 # this is also needed for normal stage3
 net-misc/curl -http2 -http3 -quic -curl_quic_openssl


### PR DESCRIPTION
`pam 1.7.0` introduced `elogind` as a dependency, resulting in circular dependency for `desktop` profile. Adding it to `circular` list to fix the build error.

```
* Error: circular dependencies:

(sys-libs/pam-1.7.0_p20241230-r3:0/0::gentoo, ebuild scheduled for merge) depends on
 (sys-auth/elogind-255.5-r2:0/0::gentoo, ebuild scheduled for merge) (buildtime)
  (sys-libs/pam-1.7.0_p20241230-r3:0/0::gentoo, ebuild scheduled for merge) (buildtime)
```