### PR TITLE
Enable emerge on installcds

### DIFF
--- a/releases/specs/amd64/installcd-stage1.spec
+++ b/releases/specs/amd64/installcd-stage1.spec
@@ -73,7 +73,12 @@ livecd/packages:
 	app-text/dos2unix
 	app-text/wgetpaste
 	app-vim/gentoo-syntax
+	dev-build/autoconf
+	dev-build/autoconf-archive
+	dev-build/automake
+	dev-build/automake-wrapper
 	dev-build/cmake
+	dev-build/libtool
 	dev-debug/strace
 	dev-lang/perl
 	dev-lang/python
@@ -153,11 +158,11 @@ livecd/packages:
 	sys-apps/pcmciautils
 	sys-apps/pv
 	sys-apps/sdparm
-	sys-apps/usbutils
 	sys-apps/sed
 	sys-apps/setserial
 	sys-apps/sg3_utils
 	sys-apps/smartmontools
+	sys-apps/texinfo
 	sys-apps/usbutils
 	sys-apps/which
 	sys-auth/ssh-import-id
@@ -170,6 +175,7 @@ livecd/packages:
 	sys-block/tw_cli
 	sys-boot/efibootmgr
 	sys-boot/grub
+	sys-devel/m4
 	sys-firmware/b43-firmware
 	sys-firmware/ipw2100-firmware
 	sys-firmware/ipw2200-firmware
@@ -198,6 +204,7 @@ livecd/packages:
 	sys-fs/xfsdump
 	sys-fs/xfsprogs
 	sys-kernel/linux-firmware
+	sys-kernel/linux-headers
 	sys-libs/gpm
 	sys-libs/libsmbios
 	sys-power/acpid

--- a/releases/specs/amd64/installcd-stage2-minimal.spec
+++ b/releases/specs/amd64/installcd-stage2-minimal.spec
@@ -30,44 +30,17 @@ livecd/unmerge:
 	app-portage/gentoolkit
 	app-arch/cpio
 	dev-build/cmake
-	dev-build/libtool
 	dev-lang/rust-bin
-	dev-libs/gmp
-	dev-libs/libxml2
-	dev-libs/mpfr
 	dev-python/pycrypto
-	dev-util/pkgconf
 	perl-core/PodParser
 	perl-core/Test-Harness
 	sys-apps/debianutils
 	sys-apps/diffutils
-	sys-apps/groff
 	sys-apps/man-db
 	sys-apps/man-pages
 	sys-apps/memtest86+
-	sys-apps/miscfiles
-	sys-apps/sandbox
-	sys-apps/texinfo
-	dev-build/autoconf
-	dev-build/autoconf-wrapper
-	dev-build/automake
-	dev-build/automake-wrapper
-	sys-devel/binutils
-	sys-devel/binutils-config
-	sys-devel/bison
-	sys-devel/flex
-	sys-devel/gcc
-	sys-devel/gcc-config
-	sys-devel/gettext
-	sys-devel/gnuconfig
-	sys-devel/m4
-	dev-build/make
-	sys-devel/patch
-	sys-libs/db
-	sys-libs/gdbm
 	sys-kernel/dracut
 	sys-kernel/gentoo-kernel
-	sys-kernel/linux-headers
 
 livecd/empty:
 	/boot
@@ -83,26 +56,21 @@ livecd/empty:
 	/etc/skel
 	/root/.ccache
 	/tmp
-	/usr/include
 	/usr/local
 	/usr/share/aclocal
 	/usr/share/baselayout
-	/usr/share/binutils-data
 	/usr/share/consolefonts/partialfonts
 	/usr/share/consoletrans
 	/usr/share/dict
 	/usr/share/doc
 	/usr/share/emacs
 	/usr/share/et
-	/usr/share/gcc-data
 	/usr/share/gettext
 	/usr/share/glib-2.0
-	/usr/share/gnuconfig
 	/usr/share/gtk-doc
 	/usr/share/i18n
 	/usr/share/info
 	/usr/share/lcms
-	/usr/share/libtool
 	/usr/share/man
 	/usr/share/rfc
 	/usr/share/ss
@@ -113,7 +81,6 @@ livecd/empty:
 	/usr/src
 	/var/cache
 	/var/empty
-	/var/lib/portage
 	/var/log
 	/var/spool
 	/var/state

--- a/releases/specs/arm64/installcd-stage1.spec
+++ b/releases/specs/arm64/installcd-stage1.spec
@@ -37,6 +37,11 @@ livecd/packages:
 	app-shells/bash-completion
 	app-shells/gentoo-bashcomp
 	app-text/wgetpaste
+	dev-build/autoconf
+	dev-build/autoconf-archive
+	dev-build/automake
+	dev-build/automake-wrapper
+	dev-build/libtool
 	dev-embedded/u-boot-tools
 	media-gfx/fbgrab
 	media-sound/alsa-utils
@@ -76,10 +81,12 @@ livecd/packages:
 	sys-apps/pv
 	sys-apps/pcmciautils
 	sys-apps/sdparm
+	sys-apps/texinfo
 	sys-apps/usbutils
 	sys-auth/ssh-import-id
 	sys-block/parted
 	sys-block/partimage
+	sys-devel/m4
 	sys-firmware/ipw2100-firmware
 	sys-firmware/ipw2200-firmware
 	sys-fs/bcache-tools
@@ -100,6 +107,7 @@ livecd/packages:
 	sys-fs/xfsdump
 	sys-fs/xfsprogs
 	sys-kernel/linux-firmware
+	sys-kernel/linux-headers
 	sys-libs/gpm
 	sys-power/acpid
 	www-client/links

--- a/releases/specs/arm64/installcd-stage2-minimal.spec
+++ b/releases/specs/arm64/installcd-stage2-minimal.spec
@@ -21,47 +21,24 @@ boot/kernel/gentoo/dracut_args: --xz --no-hostonly -a dmsquash-live -a mdraid -o
 boot/kernel/gentoo/packages: --usepkg n zfs zfs-kmod
 
 livecd/unmerge:
-	app-admin/eselect
 	app-admin/eselect-ctags
 	app-admin/eselect-vi
 	app-admin/perl-cleaner
 	app-admin/python-updater
+	app-portage/gentoolkit
 	app-arch/cpio
-        dev-build/libtool
-	dev-libs/gmp
-	dev-libs/libxml2
-	dev-libs/mpfr
+	dev-build/cmake
+	dev-lang/rust-bin
 	dev-python/pycrypto
-	dev-util/pkgconf
 	perl-core/PodParser
 	perl-core/Test-Harness
 	sys-apps/debianutils
 	sys-apps/diffutils
-	sys-apps/groff
 	sys-apps/man-db
 	sys-apps/man-pages
-	sys-apps/miscfiles
-	sys-apps/sandbox
-	sys-apps/texinfo
-	dev-build/autoconf
-	dev-build/autoconf-wrapper
-	dev-build/automake
-	dev-build/automake-wrapper
-	sys-devel/binutils
-	sys-devel/binutils-config
-	sys-devel/bison
-	sys-devel/flex
-	sys-devel/gcc
-	sys-devel/gcc-config
-	sys-devel/gettext
-	sys-devel/gnuconfig
-	sys-devel/m4
-	dev-build/make
-	sys-devel/patch
-	sys-libs/db
-	sys-libs/gdbm
-	sys-kernel/genkernel
-	sys-kernel/linux-headers
+	sys-apps/memtest86+
+	sys-kernel/dracut
+	sys-kernel/gentoo-kernel
 
 livecd/empty:
 	/boot
@@ -69,59 +46,29 @@ livecd/empty:
 	/etc/cron.hourly
 	/etc/cron.monthly
 	/etc/cron.weekly
+	/etc/kernel/config.d
 	/etc/logrotate.d
 	/etc/modules.autoload.d
 	/etc/rsync
 	/etc/runlevels/single
 	/etc/skel
-	/usr/lib/dev-state
-	/usr/lib/udev-state
-	/usr/lib64/dev-state
-	/usr/lib64/udev-state
 	/root/.ccache
 	/tmp
-	/usr/diet/include
-	/usr/diet/man
-	/usr/include
-	/usr/lib/X11/config
-	/usr/lib/X11/doc
-	/usr/lib/X11/etc
-	/usr/lib/awk
-	/usr/lib/ccache
-	/usr/lib/gcc-config
-	/usr/lib/nfs
-	/usr/lib/perl5/site_perl
-	/usr/lib/portage
-	/usr/lib64/X11/config
-	/usr/lib64/X11/doc
-	/usr/lib64/X11/etc
-	/usr/lib64/awk
-	/usr/lib64/ccache
-	/usr/lib64/gcc-config
-	/usr/lib64/nfs
-	/usr/lib64/perl5/site_perl
-	/usr/lib64/portage
 	/usr/local
-	/usr/portage
 	/usr/share/aclocal
 	/usr/share/baselayout
-	/usr/share/binutils-data
 	/usr/share/consolefonts/partialfonts
 	/usr/share/consoletrans
 	/usr/share/dict
 	/usr/share/doc
 	/usr/share/emacs
 	/usr/share/et
-	/usr/share/gcc-data
-	/usr/share/genkernel
 	/usr/share/gettext
 	/usr/share/glib-2.0
-	/usr/share/gnuconfig
 	/usr/share/gtk-doc
 	/usr/share/i18n
 	/usr/share/info
 	/usr/share/lcms
-	/usr/share/libtool
 	/usr/share/man
 	/usr/share/rfc
 	/usr/share/ss
@@ -132,34 +79,21 @@ livecd/empty:
 	/usr/src
 	/var/cache
 	/var/empty
-	/var/lib/portage
 	/var/log
 	/var/spool
 	/var/state
 	/var/tmp
 
 livecd/rm:
-	/boot/System*
-	/boot/initr*
-	/boot/kernel*
 	/etc/*-
 	/etc/*.old
 	/etc/default/audioctl
 	/etc/dispatch-conf.conf
-	/etc/env.d/05binutils
-	/etc/env.d/05gcc
 	/etc/etc-update.conf
 	/etc/hosts.bck
 	/etc/issue*
-	/etc/genkernel.conf
-	/etc/make.conf*
-	/etc/make.globals
-	/etc/make.profile
 	/etc/man.conf
 	/etc/resolv.conf
-	/usr/lib*/*.a
-	/usr/lib*/*.la
-	/usr/lib*/cpp
 	/root/.bash_history
 	/root/.viminfo
 	/usr/bin/*.static
@@ -169,55 +103,6 @@ livecd/rm:
 	/usr/bin/mkfs.cramfs
 	/usr/bin/mkfs.minix
 	/usr/bin/addr2line
-	/usr/bin/ar
-	/usr/bin/as
-	/usr/bin/audioctl
-	/usr/bin/c++*
-	/usr/bin/cc
-	/usr/bin/cjpeg
-	/usr/bin/cpp
-	/usr/bin/djpeg
-	/usr/bin/ebuild
-	/usr/bin/egencache
-	/usr/bin/emerge
-	/usr/bin/emerge-webrsync
-	/usr/bin/emirrordist
-	/usr/bin/elftoaout
-	/usr/bin/f77
-	/usr/bin/g++*
-	/usr/bin/g77
-	/usr/bin/gcc*
-	/usr/bin/genkernel
-	/usr/bin/gprof
-	/usr/bin/aarch64-unknown-linux-*
-	/usr/bin/jpegtran
-	/usr/bin/ld
-	/usr/bin/libpng*
-	/usr/bin/nm
-	/usr/bin/objcopy
-	/usr/bin/objdump
-	/usr/bin/piggyback*
-	/usr/bin/portageq
-	/usr/bin/ranlib
-	/usr/bin/readelf
-	/usr/bin/size
-	/usr/bin/strip
-	/usr/bin/tbz2tool
-	/usr/bin/xpak
-	/usr/bin/yacc
-	/usr/lib*/*.a
-	/usr/lib*/*.la
-	/usr/lib*/perl5/site_perl
-	/usr/lib*/gcc-lib/*/*/libgcj*
-	/usr/bin/archive-conf
-	/usr/bin/dispatch-conf
-	/usr/bin/emaint
-	/usr/bin/env-update
-	/usr/bin/etc-update
-	/usr/bin/fb*
-	/usr/bin/fixpackages
-	/usr/bin/quickpkg
-	/usr/bin/regenworld
 	/usr/share/consolefonts/1*
 	/usr/share/consolefonts/7*
 	/usr/share/consolefonts/8*

--- a/releases/specs/ppc/ppc64le/installcd-stage1.spec
+++ b/releases/specs/ppc/ppc64le/installcd-stage1.spec
@@ -36,6 +36,11 @@ livecd/packages:
 	app-shells/bash-completion
 	app-shells/gentoo-bashcomp
 	app-text/wgetpaste
+	dev-build/autoconf
+	dev-build/autoconf-archive
+	dev-build/automake
+	dev-build/automake-wrapper
+	dev-build/libtool
 	dev-embedded/u-boot-tools
 	dev-vcs/git
 	net-analyzer/tcptraceroute
@@ -77,10 +82,12 @@ livecd/packages:
 	sys-apps/ppc64-diag
 	sys-apps/pv
 	sys-apps/sdparm
+	sys-apps/texinfo
 	sys-apps/usbutils
 	sys-auth/ssh-import-id
 	sys-block/parted
 	sys-boot/grub
+	sys-devel/m4
 	sys-fs/bcache-tools
 	sys-fs/btrfs-progs
 	sys-fs/cryptsetup
@@ -103,6 +110,7 @@ livecd/packages:
 	sys-fs/xfsdump
 	sys-fs/xfsprogs
 	sys-kernel/linux-firmware
+	sys-kernel/linux-headers
 	sys-libs/gpm
 	sys-process/htop
 	sys-process/lsof

--- a/releases/specs/ppc/ppc64le/installcd-stage2-minimal.spec
+++ b/releases/specs/ppc/ppc64le/installcd-stage2-minimal.spec
@@ -21,48 +21,24 @@ boot/kernel/gentoo/config: @REPO_DIR@/releases/kconfig/powerpc/dist-ppc64le-live
 boot/kernel/gentoo/packages: --usepkg n zfs zfs-kmod
 
 livecd/unmerge:
-	app-admin/eselect
 	app-admin/eselect-ctags
 	app-admin/eselect-vi
 	app-admin/perl-cleaner
 	app-admin/python-updater
-	app-arch/cpio
 	app-portage/gentoolkit
-	dev-build/libtool
-	dev-libs/gmp
-	dev-libs/libxml2
-	dev-libs/mpfr
+	app-arch/cpio
+	dev-build/cmake
+	dev-lang/rust-bin
 	dev-python/pycrypto
-	dev-util/pkgconf
 	perl-core/PodParser
 	perl-core/Test-Harness
 	sys-apps/debianutils
 	sys-apps/diffutils
-	sys-apps/groff
 	sys-apps/man-db
 	sys-apps/man-pages
-	sys-apps/miscfiles
-	sys-apps/sandbox
-	sys-apps/texinfo
-	dev-build/autoconf
-	dev-build/autoconf-wrapper
-	dev-build/automake
-	dev-build/automake-wrapper
-	sys-devel/binutils
-	sys-devel/binutils-config
-	sys-devel/bison
-	sys-devel/flex
-	sys-devel/gcc
-	sys-devel/gcc-config
-	sys-devel/gettext
-	sys-devel/gnuconfig
-	sys-devel/m4
-	dev-build/make
-	sys-devel/patch
-	sys-libs/db
-	sys-libs/gdbm
-	sys-kernel/genkernel
-	sys-kernel/linux-headers
+	sys-apps/memtest86+
+	sys-kernel/dracut
+	sys-kernel/gentoo-kernel
 
 livecd/empty:
 	/boot
@@ -70,51 +46,29 @@ livecd/empty:
 	/etc/cron.hourly
 	/etc/cron.monthly
 	/etc/cron.weekly
-	/etc/logrotate.d
 	/etc/kernel/config.d
+	/etc/logrotate.d
 	/etc/modules.autoload.d
 	/etc/rsync
 	/etc/runlevels/single
 	/etc/skel
-	/usr/lib/dev-state
-	/usr/lib/udev-state
-	/usr/lib64/dev-state
-	/usr/lib64/udev-state
 	/root/.ccache
 	/tmp
-	/usr/include
-	/usr/lib64/X11/config
-	/usr/lib64/X11/doc
-	/usr/lib64/X11/etc
-	/usr/lib64/awk
-	/usr/lib64/ccache
-	/usr/lib64/gcc-config
-	/usr/lib64/nfs
-	/usr/lib64/perl5/site_perl
-	/usr/lib64/portage
 	/usr/local
-	/usr/portage
-	/usr/powerpc64*-unknown-linux-gnu
 	/usr/share/aclocal
 	/usr/share/baselayout
-	/usr/share/binutils-data
 	/usr/share/consolefonts/partialfonts
 	/usr/share/consoletrans
 	/usr/share/dict
 	/usr/share/doc
 	/usr/share/emacs
 	/usr/share/et
-	/usr/share/gcc-data
-	/usr/share/genkernel
 	/usr/share/gettext
 	/usr/share/glib-2.0
-	/usr/share/gnuconfig
 	/usr/share/gtk-doc
 	/usr/share/i18n
 	/usr/share/info
 	/usr/share/lcms
-	/usr/share/libtool
-	/usr/share/locale
 	/usr/share/man
 	/usr/share/rfc
 	/usr/share/ss
@@ -125,34 +79,21 @@ livecd/empty:
 	/usr/src
 	/var/cache
 	/var/empty
-	/var/lib/portage
 	/var/log
 	/var/spool
 	/var/state
 	/var/tmp
 
 livecd/rm:
-	/boot/System*
-	/boot/initr*
-	/boot/kernel*
 	/etc/*-
 	/etc/*.old
 	/etc/default/audioctl
 	/etc/dispatch-conf.conf
-	/etc/env.d/05binutils
-	/etc/env.d/05gcc
 	/etc/etc-update.conf
 	/etc/hosts.bck
 	/etc/issue*
-	/etc/genkernel.conf
-	/etc/make.conf*
-	/etc/make.globals
-	/etc/make.profile
 	/etc/man.conf
 	/etc/resolv.conf
-	/usr/lib*/*.a
-	/usr/lib*/*.la
-	/usr/lib*/cpp
 	/root/.bash_history
 	/root/.viminfo
 	/usr/bin/*.static
@@ -162,56 +103,6 @@ livecd/rm:
 	/usr/bin/mkfs.cramfs
 	/usr/bin/mkfs.minix
 	/usr/bin/addr2line
-	/usr/bin/ar
-	/usr/bin/as
-	/usr/bin/audioctl
-	/usr/bin/c++*
-	/usr/bin/cc
-	/usr/bin/cjpeg
-	/usr/bin/cpp
-	/usr/bin/djpeg
-	/usr/bin/ebuild
-	/usr/bin/egencache
-	/usr/bin/emerge
-	/usr/bin/emerge-webrsync
-	/usr/bin/emirrordist
-	/usr/bin/elftoaout
-	/usr/bin/f77
-	/usr/bin/g++*
-	/usr/bin/g77
-	/usr/bin/gcc*
-	/usr/bin/genkernel
-	/usr/bin/gprof
-	/usr/bin/jpegtran
-	/usr/bin/ld
-	/usr/bin/libpng*
-	/usr/bin/nm
-	/usr/bin/objcopy
-	/usr/bin/objdump
-	/usr/bin/piggyback*
-	/usr/bin/portageq
-	/usr/bin/ranlib
-	/usr/bin/readelf
-	/usr/bin/size
-	/usr/bin/powerpc64*-unknown-linux-gnu-*
-	/usr/bin/strings
-	/usr/bin/strip
-	/usr/bin/tbz2tool
-	/usr/bin/xpak
-	/usr/bin/yacc
-	/usr/lib*/*.a
-	/usr/lib*/*.la
-	/usr/lib*/perl5/site_perl
-	/usr/lib*/gcc-lib/*/*/libgcj*
-	/usr/bin/archive-conf
-	/usr/bin/dispatch-conf
-	/usr/bin/emaint
-	/usr/bin/env-update
-	/usr/bin/etc-update
-	/usr/bin/fb*
-	/usr/bin/fixpackages
-	/usr/bin/quickpkg
-	/usr/bin/regenworld
 	/usr/share/consolefonts/1*
 	/usr/share/consolefonts/7*
 	/usr/share/consolefonts/8*

--- a/releases/specs/x86/i486/installcd-stage1-openrc.spec
+++ b/releases/specs/x86/i486/installcd-stage1-openrc.spec
@@ -35,8 +35,13 @@ livecd/packages:
 	app-portage/gentoolkit
 	app-portage/mirrorselect
 	app-text/wgetpaste
+	dev-build/autoconf
+	dev-build/autoconf-archive
+	dev-build/automake
+	dev-build/automake-wrapper
 	dev-build/cmake
 	dev-debug/strace
+	dev-build/libtool
 	media-gfx/fbgrab
 	media-sound/alsa-utils
 	net-analyzer/traceroute
@@ -78,11 +83,13 @@ livecd/packages:
 	sys-apps/pcmciautils
 	sys-apps/pv
 	sys-apps/sdparm
+	sys-apps/texinfo
 	sys-apps/usbutils
 	sys-auth/ssh-import-id
 	sys-block/parted
 	sys-block/partimage
 	sys-boot/efibootmgr
+	sys-devel/m4
 	sys-firmware/b43-firmware
 	sys-firmware/ipw2100-firmware
 	sys-firmware/ipw2200-firmware
@@ -106,6 +113,7 @@ livecd/packages:
 	sys-fs/xfsdump
 	sys-fs/xfsprogs
 	sys-kernel/linux-firmware
+	sys-kernel/linux-headers
 	#force rebuild for USE="(-multilib*)"
 	sys-libs/glibc
 	sys-libs/gpm

--- a/releases/specs/x86/i486/installcd-stage2-minimal-openrc.spec
+++ b/releases/specs/x86/i486/installcd-stage2-minimal-openrc.spec
@@ -28,47 +28,20 @@ livecd/unmerge:
 	app-admin/eselect-vi
 	app-admin/perl-cleaner
 	app-admin/python-updater
-	app-arch/cpio
 	app-portage/gentoolkit
+	app-arch/cpio
 	dev-build/cmake
-	dev-build/libtool
 	dev-lang/rust-bin
-	dev-libs/gmp
-	dev-libs/libxml2
-	dev-libs/mpfr
 	dev-python/pycrypto
 	perl-core/PodParser
 	perl-core/Test-Harness
 	sys-apps/debianutils
 	sys-apps/diffutils
-	sys-apps/groff
 	sys-apps/man-db
 	sys-apps/man-pages
 	sys-apps/memtest86+
-	sys-apps/miscfiles
-	sys-apps/sandbox
-	sys-apps/texinfo
-	dev-build/autoconf
-	dev-build/autoconf-wrapper
-	dev-build/automake
-	dev-build/automake-wrapper
-	sys-devel/binutils
-	sys-devel/binutils-config
-	sys-devel/bison
-	sys-devel/flex
-	sys-devel/gcc
-	sys-devel/gcc-config
-	sys-devel/gettext
-	sys-devel/gnuconfig
-	sys-devel/m4
-	dev-build/make
-	sys-devel/patch
-	sys-libs/db
-	sys-libs/gdbm
 	sys-kernel/dracut
 	sys-kernel/gentoo-kernel
-	sys-kernel/linux-headers
-
 
 livecd/empty:
 	/boot
@@ -84,26 +57,21 @@ livecd/empty:
 	/etc/skel
 	/root/.ccache
 	/tmp
-	/usr/include
 	/usr/local
 	/usr/share/aclocal
 	/usr/share/baselayout
-	/usr/share/binutils-data
 	/usr/share/consolefonts/partialfonts
 	/usr/share/consoletrans
 	/usr/share/dict
 	/usr/share/doc
 	/usr/share/emacs
 	/usr/share/et
-	/usr/share/gcc-data
 	/usr/share/gettext
 	/usr/share/glib-2.0
-	/usr/share/gnuconfig
 	/usr/share/gtk-doc
 	/usr/share/i18n
 	/usr/share/info
 	/usr/share/lcms
-	/usr/share/libtool
 	/usr/share/man
 	/usr/share/rfc
 	/usr/share/ss
@@ -114,7 +82,6 @@ livecd/empty:
 	/usr/src
 	/var/cache
 	/var/empty
-	/var/lib/portage
 	/var/log
 	/var/spool
 	/var/state


### PR DESCRIPTION
Allow the use of the emerge command inside the installcd so a user can preform even more system fixing tasks if required. System fixing can be called by first mounting the system root to /mnt/gentoo then using `emerge --root /mnt/gentoo <package name>`

Examples of when this could be useful:

- User breaks a system tool like util-linux (seen in a support question) 
- User wishes to change from GCC to Clang as the default compiler (minimises of ABI breakage when a user refuses to "reinstall") 

File increase on amd64 is roughly 109MB which I feel is worth the extra space for a true admincd that a user can fix any issue they could possibly cause to their system. I don't have access to arm64 or ppc64le hw to be 100% sure on the file size increase but it's safe to assume it will be around the 109MB mark.

on x86 the increase is around 67MB, this still makes it under the standard CDR size (700MB) so added as well.

I have split the commits per arch so it's easier for Gentoo to pick which arches get this feature.

Note: I have only converted the dist kernel redesigned images for now, I will add the rest if agreed, when I convert the remaining arches which dist kernel currently does not support and complete the package list refresh on those arches.