### PR TITLE
releases/specs/{amd64,arm64,x86}: enable support for booting with NTFS filesystem

### DIFF
--- a/releases/specs/amd64/installcd-stage2-minimal.spec
+++ b/releases/specs/amd64/installcd-stage2-minimal.spec
@@ -18,7 +18,7 @@ livecd/rcadd: dbus|default gpm|default NetworkManager|default
 boot/kernel: gentoo
 
 boot/kernel/gentoo/distkernel: yes
-boot/kernel/gentoo/dracut_args: --xz --no-hostonly -a dmsquash-live -a mdraid -o btrfs -o crypt -o i18n -o usrmount -o lunmask -o qemu -o qemu-net -o nvdimm -o multipath -i /lib/keymaps /lib/keymaps -I busybox
+boot/kernel/gentoo/dracut_args: --xz --no-hostonly -a dmsquash-live -a dmsquash-live-ntfs -a mdraid -o btrfs -o crypt -o i18n -o usrmount -o lunmask -o qemu -o qemu-net -o nvdimm -o multipath -i /lib/keymaps /lib/keymaps -I busybox
 boot/kernel/gentoo/config: @REPO_DIR@/releases/kconfig/amd64/dist-amd64-livecd.config
 boot/kernel/gentoo/packages: --usepkg n net-wireless/broadcom-sta sys-fs/zfs
 

--- a/releases/specs/amd64/livegui/livegui-stage2.spec
+++ b/releases/specs/amd64/livegui/livegui-stage2.spec
@@ -25,5 +25,5 @@ livecd/empty:
 boot/kernel: gentoo
 
 boot/kernel/gentoo/distkernel: yes
-boot/kernel/gentoo/dracut_args: --xz --no-hostonly -a dmsquash-live -a mdraid -o btrfs -o crypt -o i18n -o usrmount -o lunmask -o qemu -o qemu-net -o nvdimm -o multipath -i /lib/keymaps /lib/keymaps -I busybox
+boot/kernel/gentoo/dracut_args: --xz --no-hostonly -a dmsquash-live -a dmsquash-live-ntfs -a mdraid -o btrfs -o crypt -o i18n -o usrmount -o lunmask -o qemu -o qemu-net -o nvdimm -o multipath -i /lib/keymaps /lib/keymaps -I busybox
 boot/kernel/gentoo/packages: --usepkg n sys-fs/zfs broadcom-sta

--- a/releases/specs/arm64/installcd-stage2-minimal.spec
+++ b/releases/specs/arm64/installcd-stage2-minimal.spec
@@ -17,7 +17,7 @@ livecd/volid: Gentoo-arm64-@TIMESTAMP@
 boot/kernel: gentoo
 
 boot/kernel/gentoo/distkernel: yes
-boot/kernel/gentoo/dracut_args: --xz --no-hostonly -a dmsquash-live -a mdraid -o btrfs -o crypt -o i18n -o usrmount -o lunmask -o qemu -o qemu-net -o nvdimm -o multipath -o zfs -i /lib/keymaps /lib/keymaps -I busybox
+boot/kernel/gentoo/dracut_args: --xz --no-hostonly -a dmsquash-live -a dmsquash-live-ntfs -a mdraid -o btrfs -o crypt -o i18n -o usrmount -o lunmask -o qemu -o qemu-net -o nvdimm -o multipath -o zfs -i /lib/keymaps /lib/keymaps -I busybox
 boot/kernel/gentoo/packages: --usepkg n zfs zfs-kmod
 
 livecd/unmerge:

--- a/releases/specs/x86/i486/installcd-stage2-minimal-openrc.spec
+++ b/releases/specs/x86/i486/installcd-stage2-minimal-openrc.spec
@@ -19,7 +19,7 @@ livecd/rcadd: dbus|default gpm|default NetworkManager|default
 boot/kernel: gentoo
 
 boot/kernel/gentoo/distkernel: yes
-boot/kernel/gentoo/dracut_args: --xz --no-hostonly -a dmsquash-live -a mdraid -o btrfs -o crypt -o i18n -o usrmount -o lunmask -o qemu -o qemu-net -o nvdimm -o multipath -o modsign -o net-lib -o bcache -o dmraid -o lvm -o resume -o virtiofs -o mdraid -o shutdown -o kernel-modules-extra -o shutdown  -o pcmcia -o hwdb -i /lib/keymaps /lib/keymaps -I busybox
+boot/kernel/gentoo/dracut_args: --xz --no-hostonly -a dmsquash-live -a dmsquash-live-ntfs -a mdraid -o btrfs -o crypt -o i18n -o usrmount -o lunmask -o qemu -o qemu-net -o nvdimm -o multipath -o modsign -o net-lib -o bcache -o dmraid -o lvm -o resume -o virtiofs -o mdraid -o shutdown -o kernel-modules-extra -o shutdown  -o pcmcia -o hwdb -i /lib/keymaps /lib/keymaps -I busybox
 boot/kernel/gentoo/config: @REPO_DIR@/releases/kconfig/x86/dist-x86-livecd.config
 boot/kernel/gentoo/packages: --usepkg n broadcom-sta
 


### PR DESCRIPTION
Add "dmsquash-live-ntfs" dracut module, which simply add the support of booting an USB media with NTFS filesystem.

**Issue description**
When booting a Gentoo amd64 minimal install in UEFI mode, I get this error: "dracut Warning: Can't mount root filesystem"

Here is the initramfs log: [rdsosreport.txt](https://github.com/user-attachments/files/22330794/rdsosreport.txt)


As noted in this Git commit message [here](https://github.com/pbatard/rufus/commit/ae377ae8cafea7a5454d1b1b0b0966bbf1f4b6f4):
"since the Gentoo maintainers appear not to have a kernel NTFS driver in the current images, the installer still fails to mount the installation media."

Now, I want to point out why using NTFS is overall a better choice

FAT file system has these 4 main limitations:
1) the filesystem label:
- can be no longer than 11 characters
- must use uppercase letters
- characters below 0x20 are not allowed
- characters *?.,;:/\\|+=<>[]\" are not allowed
- can't start with a space character
- must contain English characters only
2) FAT16B and FAT32 have a maximum file size of 4 GiB
3) do not support symbolic links because their design predates the feature and lacks a mechanism to mark files as links
4) do not support UNIX file permissions

In addition to this, newer UEFI motherboards from major brands (Gigabyte, ASUS, MSI, Intel, etc.) already have an UEFI NTFS driver in their firmware so this mean they can natively boot from this filesystem (in addition to FAT, which is mandatory per UEFI specs)

With this addition, we are ensuring the boot process now honour one of the 3 requirements for [File System Transposition](https://github.com/pbatard/rufus/issues/2127#issuecomment-1370336621) support