### PR TITLE
livecds: leave manual pages and associated tooling intact

### DIFF
--- a/releases/specs-qemu/alpha/installcd-stage2-minimal.spec
+++ b/releases/specs-qemu/alpha/installcd-stage2-minimal.spec
@@ -68,8 +68,6 @@ livecd/unmerge:
 	sys-apps/diffutils
 	sys-apps/file
 	sys-apps/groff
-	sys-apps/man-db
-	sys-apps/man-pages
 	sys-apps/miscfiles
 	sys-apps/sandbox
 	sys-apps/texinfo
@@ -111,7 +109,6 @@ livecd/empty:
 	/root/.ccache
 	/tmp
 	/usr/diet/include
-	/usr/diet/man
 	/usr/include
 	/usr/i386-gentoo-linux-uclibc
 	/usr/i386-pc-linux-gnu
@@ -158,7 +155,6 @@ livecd/empty:
 	/usr/share/lcms
 	/usr/share/libtool
 	/usr/share/locale
-	/usr/share/man
 	/usr/share/rfc
 	/usr/share/ss
 	/usr/share/state
@@ -193,7 +189,6 @@ livecd/rm:
 	/etc/make.conf*
 	/etc/make.globals
 	/etc/make.profile
-	/etc/man.conf
 	/etc/resolv.conf
 	/usr/lib*/*.a
 	/usr/lib*/*.la

--- a/releases/specs-qemu/hppa/installcd-stage2-minimal.spec
+++ b/releases/specs-qemu/hppa/installcd-stage2-minimal.spec
@@ -97,8 +97,6 @@ livecd/unmerge:
 	sys-apps/debianutils
 	sys-apps/diffutils
 	sys-apps/groff
-	sys-apps/help2man
-	sys-apps/man-db
 	sys-apps/sandbox
 	sys-apps/tcp-wrappers
 	sys-apps/texinfo
@@ -145,7 +143,6 @@ livecd/empty:
 	/root/.ccache
 	/tmp
 	/usr/diet/include
-	/usr/diet/man
 	/usr/include
 	/usr/hppa*-unknown-linux-*
 	/usr/include
@@ -189,7 +186,6 @@ livecd/empty:
 	/usr/share/lcms
 	/usr/share/libtool
 	/usr/share/locale
-	/usr/share/man
 	/usr/share/rfc
 	/usr/share/ss
 	/usr/share/state
@@ -224,7 +220,6 @@ livecd/rm:
 	/etc/make.conf*
 	/etc/make.globals
 	/etc/make.profile
-	/etc/man.conf
 	/etc/resolv.conf
 	/usr/lib*/*.a
 	/usr/lib*/*.la

--- a/releases/specs-qemu/sparc/sparc64/installcd-stage2-minimal.spec
+++ b/releases/specs-qemu/sparc/sparc64/installcd-stage2-minimal.spec
@@ -39,8 +39,6 @@ livecd/unmerge:
 	sys-apps/debianutils
 	sys-apps/diffutils
 	sys-apps/groff
-	sys-apps/man-db
-	sys-apps/man-pages
 	sys-apps/miscfiles
 	sys-apps/sandbox
 	sys-apps/texinfo
@@ -82,7 +80,6 @@ livecd/empty:
 	/root/.ccache
 	/tmp
 	/usr/diet/include
-	/usr/diet/man
 	/usr/include
 	/usr/i?86-gentoo-linux-uclibc
 	/usr/i386-pc-linux-gnu
@@ -127,7 +124,6 @@ livecd/empty:
 	/usr/share/lcms
 	/usr/share/libtool
 	/usr/share/locale
-	/usr/share/man
 	/usr/share/rfc
 	/usr/share/ss
 	/usr/share/state
@@ -163,7 +159,6 @@ livecd/rm:
 	/etc/make.conf*
 	/etc/make.globals
 	/etc/make.profile
-	/etc/man.conf
 	/etc/resolv.conf
 	/usr/lib*/*.a
 	/usr/lib*/*.la

--- a/releases/specs/amd64/installcd-stage2-minimal.spec
+++ b/releases/specs/amd64/installcd-stage2-minimal.spec
@@ -42,8 +42,6 @@ livecd/unmerge:
 	sys-apps/debianutils
 	sys-apps/diffutils
 	sys-apps/groff
-	sys-apps/man-db
-	sys-apps/man-pages
 	sys-apps/memtest86+
 	sys-apps/miscfiles
 	sys-apps/sandbox
@@ -103,7 +101,6 @@ livecd/empty:
 	/usr/share/info
 	/usr/share/lcms
 	/usr/share/libtool
-	/usr/share/man
 	/usr/share/rfc
 	/usr/share/ss
 	/usr/share/state
@@ -127,7 +124,6 @@ livecd/rm:
 	/etc/etc-update.conf
 	/etc/hosts.bck
 	/etc/issue*
-	/etc/man.conf
 	/etc/resolv.conf
 	/root/.bash_history
 	/root/.viminfo

--- a/releases/specs/arm64/installcd-stage2-minimal.spec
+++ b/releases/specs/arm64/installcd-stage2-minimal.spec
@@ -38,8 +38,6 @@ livecd/unmerge:
 	sys-apps/debianutils
 	sys-apps/diffutils
 	sys-apps/groff
-	sys-apps/man-db
-	sys-apps/man-pages
 	sys-apps/miscfiles
 	sys-apps/sandbox
 	sys-apps/texinfo
@@ -81,7 +79,6 @@ livecd/empty:
 	/root/.ccache
 	/tmp
 	/usr/diet/include
-	/usr/diet/man
 	/usr/include
 	/usr/lib/X11/config
 	/usr/lib/X11/doc
@@ -122,7 +119,6 @@ livecd/empty:
 	/usr/share/info
 	/usr/share/lcms
 	/usr/share/libtool
-	/usr/share/man
 	/usr/share/rfc
 	/usr/share/ss
 	/usr/share/state
@@ -155,7 +151,6 @@ livecd/rm:
 	/etc/make.conf*
 	/etc/make.globals
 	/etc/make.profile
-	/etc/man.conf
 	/etc/resolv.conf
 	/usr/lib*/*.a
 	/usr/lib*/*.la

--- a/releases/specs/hppa/installcd-stage2-minimal.spec
+++ b/releases/specs/hppa/installcd-stage2-minimal.spec
@@ -96,8 +96,6 @@ livecd/unmerge:
 	sys-apps/debianutils
 	sys-apps/diffutils
 	sys-apps/groff
-	sys-apps/help2man
-	sys-apps/man-db
 	sys-apps/sandbox
 	sys-apps/tcp-wrappers
 	sys-apps/texinfo
@@ -144,7 +142,6 @@ livecd/empty:
 	/root/.ccache
 	/tmp
 	/usr/diet/include
-	/usr/diet/man
 	/usr/include
 	/usr/hppa*-unknown-linux-*
 	/usr/include
@@ -188,7 +185,6 @@ livecd/empty:
 	/usr/share/lcms
 	/usr/share/libtool
 	/usr/share/locale
-	/usr/share/man
 	/usr/share/rfc
 	/usr/share/ss
 	/usr/share/state
@@ -223,7 +219,6 @@ livecd/rm:
 	/etc/make.conf*
 	/etc/make.globals
 	/etc/make.profile
-	/etc/man.conf
 	/etc/resolv.conf
 	/usr/lib*/*.a
 	/usr/lib*/*.la

--- a/releases/specs/ia64/installcd-stage2-minimal.spec
+++ b/releases/specs/ia64/installcd-stage2-minimal.spec
@@ -48,8 +48,6 @@ livecd/unmerge:
 	sys-apps/diffutils
 	sys-apps/file
 	sys-apps/groff
-	sys-apps/man-db
-	sys-apps/man-pages
 	sys-apps/miscfiles
 	sys-apps/sandbox
 	sys-apps/texinfo
@@ -90,7 +88,6 @@ livecd/empty:
 	/root/.ccache
 	/tmp
 	/usr/diet/include
-	/usr/diet/man
 	/usr/include
 	/usr/i386-gentoo-linux-uclibc
 	/usr/i386-pc-linux-gnu
@@ -137,7 +134,6 @@ livecd/empty:
 	/usr/share/lcms
 	/usr/share/libtool
 	/usr/share/locale
-	/usr/share/man
 	/usr/share/rfc
 	/usr/share/ss
 	/usr/share/state
@@ -172,7 +168,6 @@ livecd/rm:
 	/etc/make.conf*
 	/etc/make.globals
 	/etc/make.profile
-	/etc/man.conf
 	/etc/resolv.conf
 	/usr/lib*/*.a
 	/usr/lib*/*.la

--- a/releases/specs/ppc/ppc32/installcd-stage2-minimal.spec
+++ b/releases/specs/ppc/ppc32/installcd-stage2-minimal.spec
@@ -85,8 +85,6 @@ livecd/unmerge:
 	sys-apps/debianutils
 	sys-apps/diffutils
 	sys-apps/groff
-	sys-apps/man-db
-	sys-apps/man-pages
 	sys-apps/miscfiles
 	sys-apps/sandbox
 	sys-apps/texinfo
@@ -127,7 +125,6 @@ livecd/empty:
 	/root/.ccache
 	/tmp
 	/usr/diet/include
-	/usr/diet/man
 	/usr/include
 	/usr/lib64/X11/config
 	/usr/lib64/X11/doc
@@ -163,7 +160,6 @@ livecd/empty:
 	/usr/share/lcms
 	/usr/share/libtool
 	/usr/share/locale
-	/usr/share/man
 	/usr/share/rfc
 	/usr/share/ss
 	/usr/share/state
@@ -196,7 +192,6 @@ livecd/rm:
 	/etc/make.conf*
 	/etc/make.globals
 	/etc/make.profile
-	/etc/man.conf
 	/etc/resolv.conf
 	/usr/lib*/*.a
 	/usr/lib*/*.la

--- a/releases/specs/ppc/ppc64le/installcd-stage2-minimal.spec
+++ b/releases/specs/ppc/ppc64le/installcd-stage2-minimal.spec
@@ -39,8 +39,6 @@ livecd/unmerge:
 	sys-apps/debianutils
 	sys-apps/diffutils
 	sys-apps/groff
-	sys-apps/man-db
-	sys-apps/man-pages
 	sys-apps/miscfiles
 	sys-apps/sandbox
 	sys-apps/texinfo
@@ -115,7 +113,6 @@ livecd/empty:
 	/usr/share/lcms
 	/usr/share/libtool
 	/usr/share/locale
-	/usr/share/man
 	/usr/share/rfc
 	/usr/share/ss
 	/usr/share/state
@@ -148,7 +145,6 @@ livecd/rm:
 	/etc/make.conf*
 	/etc/make.globals
 	/etc/make.profile
-	/etc/man.conf
 	/etc/resolv.conf
 	/usr/lib*/*.a
 	/usr/lib*/*.la

--- a/releases/specs/sparc/sparc64/installcd-stage2-minimal.spec
+++ b/releases/specs/sparc/sparc64/installcd-stage2-minimal.spec
@@ -38,8 +38,6 @@ livecd/unmerge:
 	sys-apps/debianutils
 	sys-apps/diffutils
 	sys-apps/groff
-	sys-apps/man-db
-	sys-apps/man-pages
 	sys-apps/miscfiles
 	sys-apps/sandbox
 	sys-apps/texinfo
@@ -81,7 +79,6 @@ livecd/empty:
 	/root/.ccache
 	/tmp
 	/usr/diet/include
-	/usr/diet/man
 	/usr/include
 	/usr/i?86-gentoo-linux-uclibc
 	/usr/i386-pc-linux-gnu
@@ -126,7 +123,6 @@ livecd/empty:
 	/usr/share/lcms
 	/usr/share/libtool
 	/usr/share/locale
-	/usr/share/man
 	/usr/share/rfc
 	/usr/share/ss
 	/usr/share/state
@@ -162,7 +158,6 @@ livecd/rm:
 	/etc/make.conf*
 	/etc/make.globals
 	/etc/make.profile
-	/etc/man.conf
 	/etc/resolv.conf
 	/usr/lib*/*.a
 	/usr/lib*/*.la

--- a/releases/specs/x86/i486/installcd-stage2-minimal-openrc.spec
+++ b/releases/specs/x86/i486/installcd-stage2-minimal-openrc.spec
@@ -42,8 +42,6 @@ livecd/unmerge:
 	sys-apps/debianutils
 	sys-apps/diffutils
 	sys-apps/groff
-	sys-apps/man-db
-	sys-apps/man-pages
 	sys-apps/memtest86+
 	sys-apps/miscfiles
 	sys-apps/sandbox
@@ -104,7 +102,6 @@ livecd/empty:
 	/usr/share/info
 	/usr/share/lcms
 	/usr/share/libtool
-	/usr/share/man
 	/usr/share/rfc
 	/usr/share/ss
 	/usr/share/state
@@ -128,7 +125,6 @@ livecd/rm:
 	/etc/etc-update.conf
 	/etc/hosts.bck
 	/etc/issue*
-	/etc/man.conf
 	/etc/resolv.conf
 	/root/.bash_history
 	/root/.viminfo


### PR DESCRIPTION
Manual pages are useful to have installed during the install process, and considering the other software now present on the livecds, there is no real reason to not have them.