### PR TITLE
20260409 fixes

### DIFF
--- a/releases/kconfig/powerpc/dist-ppc-livecd.config
+++ b/releases/kconfig/powerpc/dist-ppc-livecd.config
@@ -1,5 +1,12 @@
 # Kernel config for PPC64LE Livecds
 
+# Ian Jordan <immoloism@gmail.com> (2026-04-09)
+# Modules for installcd to work
+CONFIG_OVERLAY_FS=y
+CONFIG_OVERLAY_FS_REDIRECT_ALWAYS_FOLLOW=y
+CONFIG_SQUASHFS=y
+
 # Ian Jordan <immoloism@gmail.com> (2026-01-28)
-# Remove localversion being set on the LiveCDs so localmodconfig doesn't double load.
+# Remove localversion being set on the LiveCDs so
+# localmodconfig doesn't double load.
 CONFIG_LOCALVERSION=""

--- a/releases/portage/livegui/package.use/installkernel
+++ b/releases/portage/livegui/package.use/installkernel
@@ -1,1 +1,0 @@
-sys-kernel/installkernel dracut

--- a/releases/specs/amd64/livegui/livegui-stage1.spec
+++ b/releases/specs/amd64/livegui/livegui-stage1.spec
@@ -255,8 +255,6 @@ livecd/packages:
 	sys-fs/squashfs-tools
 	sys-fs/xfsdump
 	sys-fs/xfsprogs
-	sys-kernel/dracut
-	sys-kernel/installkernel
 	sys-kernel/linux-firmware
 	sys-libs/gpm
 	sys-power/acpid


### PR DESCRIPTION
Weekly collection of fixes for live media builds.

PPC: Added overlayfs and squashfs support to dist kernel config.

LiveGUI: Fix out of order package installation for gentoo-kernel and chroot detection errors it causes. 