### PR TITLE
s390x: Dist kernel support

### DIFF
--- a/releases/specs/s390/s390x/netboot/netboot.spec
+++ b/releases/specs/s390/s390x/netboot/netboot.spec
@@ -13,10 +13,9 @@ portage_prefix: releng
 portage_confdir: @REPO_DIR@/releases/specs/s390/s390x/netboot/portage
 
 
-boot/kernel:                      netboot64
-boot/kernel/netboot64/sources:       sys-kernel/gentoo-sources
-boot/kernel/netboot64/config: ../../kconfig/netboot64.config
-boot/kernel/netboot64/gk_kernargs:   --all-ramdisk-modules
+boot/kernel:netboot64
+boot/kernel/netboot64/distkernel: yes
+boot/kernel/netboot64/dracut_args: --xz --no-hostonly -a dmsquash-live -a mdraid -o btrfs -o crypt -o i18n -o usrmount -o lunmask -o qemu -o qemu-net -o nvdimm -o multipath -i /lib/keymaps /lib/keymaps -I busybox
 
 netboot/use:
  multicall


### PR DESCRIPTION
Can't see any reason for this not work, but no real way to test.

Very easy to fix on the fly though so there is
little risk to Gentoo of things going wrong.

Draft until https://github.com/gentoo/gentoo/pull/46244 is merged