### PR TITLE
livegui: drop net-irc/quassel for now

### DIFF
--- a/releases/specs/amd64/livegui/livegui-stage1.spec
+++ b/releases/specs/amd64/livegui/livegui-stage1.spec
@@ -146,7 +146,6 @@ livecd/packages:
 	net-irc/irssi
 	net-irc/weechat
 	net-misc/chrony
-	net-misc/chrony
 	net-misc/dhcpcd
 	net-misc/iputils
 	net-misc/ndisc6

--- a/releases/specs/amd64/livegui/livegui-stage1.spec
+++ b/releases/specs/amd64/livegui/livegui-stage1.spec
@@ -144,7 +144,6 @@ livecd/packages:
 	net-im/pidgin
 	net-irc/hexchat
 	net-irc/irssi
-	net-irc/quassel
 	net-irc/weechat
 	net-misc/chrony
 	net-misc/chrony


### PR DESCRIPTION
There's no stable version anymore because we're using snapshots from
a branch for Qt6.

Signed-off-by: Sam James <sam@gentoo.org>