### PR TITLE
Emacs fix

### DIFF
--- a/releases/specs-qemu/alpha/installcd-stage2-minimal.spec
+++ b/releases/specs-qemu/alpha/installcd-stage2-minimal.spec
@@ -145,7 +145,6 @@ livecd/empty:
 	/usr/share/consoletrans
 	/usr/share/dict
 	/usr/share/doc
-	/usr/share/emacs
 	/usr/share/et
 	/usr/share/gcc-data
 	/usr/share/genkernel

--- a/releases/specs-qemu/hppa/installcd-stage2-minimal.spec
+++ b/releases/specs-qemu/hppa/installcd-stage2-minimal.spec
@@ -176,7 +176,6 @@ livecd/empty:
 	/usr/share/consoletrans
 	/usr/share/dict
 	/usr/share/doc
-	/usr/share/emacs
 	/usr/share/et
 	/usr/share/gcc-data
 	/usr/share/genkernel

--- a/releases/specs-qemu/loong/installcd-stage2-minimal.spec
+++ b/releases/specs-qemu/loong/installcd-stage2-minimal.spec
@@ -110,7 +110,6 @@ livecd/empty:
 	/usr/share/consoletrans
 	/usr/share/dict
 	/usr/share/doc
-	/usr/share/emacs
 	/usr/share/et
 	/usr/share/gcc-data
 	/usr/share/genkernel

--- a/releases/specs-qemu/riscv/rv64_lp64d/installcd-stage2-minimal.spec
+++ b/releases/specs-qemu/riscv/rv64_lp64d/installcd-stage2-minimal.spec
@@ -110,7 +110,6 @@ livecd/empty:
 	/usr/share/consoletrans
 	/usr/share/dict
 	/usr/share/doc
-	/usr/share/emacs
 	/usr/share/et
 	/usr/share/gcc-data
 	/usr/share/genkernel

--- a/releases/specs-qemu/sparc/sparc64/installcd-stage2-minimal-dist.spec
+++ b/releases/specs-qemu/sparc/sparc64/installcd-stage2-minimal-dist.spec
@@ -112,7 +112,6 @@ livecd/empty:
 	/usr/share/consoletrans
 	/usr/share/dict
 	/usr/share/doc
-	/usr/share/emacs
 	/usr/share/et
 	/usr/share/gcc-data
 	/usr/share/genkernel

--- a/releases/specs-qemu/sparc/sparc64/installcd-stage2-minimal.spec
+++ b/releases/specs-qemu/sparc/sparc64/installcd-stage2-minimal.spec
@@ -114,7 +114,6 @@ livecd/empty:
 	/usr/share/consoletrans
 	/usr/share/dict
 	/usr/share/doc
-	/usr/share/emacs
 	/usr/share/et
 	/usr/share/gcc-data
 	/usr/share/genkernel

--- a/releases/specs/amd64/installcd-stage1.spec
+++ b/releases/specs/amd64/installcd-stage1.spec
@@ -163,7 +163,6 @@ livecd/packages:
 	sys-firmware/ipw2200-firmware
 	sys-firmware/sof-firmware
 	sys-fs/bcache-tools
-	sys-fs/bcachefs-tools
 	sys-fs/btrfs-progs
 	sys-fs/cryptsetup
 	sys-fs/ddrescue

--- a/releases/specs/amd64/installcd-stage2-minimal.spec
+++ b/releases/specs/amd64/installcd-stage2-minimal.spec
@@ -119,7 +119,6 @@ livecd/empty:
 	/usr/share/consoletrans
 	/usr/share/dict
 	/usr/share/doc
-	/usr/share/emacs
 	/usr/share/et
 	/usr/share/gcc-data
 	/usr/share/genkernel

--- a/releases/specs/amd64/livegui/livegui-stage1.spec
+++ b/releases/specs/amd64/livegui/livegui-stage1.spec
@@ -230,7 +230,6 @@ livecd/packages:
 	sys-firmware/ipw2200-firmware
 	sys-firmware/sof-firmware
 	sys-fs/bcache-tools
-	sys-fs/bcachefs-tools
 	sys-fs/btrfs-progs
 	sys-fs/cryptsetup
 	sys-fs/ddrescue

--- a/releases/specs/arm64/installcd-stage2-minimal.spec
+++ b/releases/specs/arm64/installcd-stage2-minimal.spec
@@ -111,7 +111,6 @@ livecd/empty:
 	/usr/share/consoletrans
 	/usr/share/dict
 	/usr/share/doc
-	/usr/share/emacs
 	/usr/share/et
 	/usr/share/gcc-data
 	/usr/share/genkernel

--- a/releases/specs/ppc/ppc32/installcd-stage2-minimal-dist.spec
+++ b/releases/specs/ppc/ppc32/installcd-stage2-minimal-dist.spec
@@ -106,7 +106,6 @@ livecd/empty:
 	/usr/share/consoletrans
 	/usr/share/dict
 	/usr/share/doc
-	/usr/share/emacs
 	/usr/share/et
 	/usr/share/gcc-data
 	/usr/share/genkernel

--- a/releases/specs/ppc/ppc32/installcd-stage2-minimal.spec
+++ b/releases/specs/ppc/ppc32/installcd-stage2-minimal.spec
@@ -151,7 +151,6 @@ livecd/empty:
 	/usr/share/consoletrans
 	/usr/share/dict
 	/usr/share/doc
-	/usr/share/emacs
 	/usr/share/et
 	/usr/share/gcc-data
 	/usr/share/genkernel

--- a/releases/specs/ppc/ppc64le/installcd-stage2-minimal.spec
+++ b/releases/specs/ppc/ppc64le/installcd-stage2-minimal.spec
@@ -102,7 +102,6 @@ livecd/empty:
 	/usr/share/consoletrans
 	/usr/share/dict
 	/usr/share/doc
-	/usr/share/emacs
 	/usr/share/et
 	/usr/share/gcc-data
 	/usr/share/genkernel

--- a/releases/specs/sparc/sparc64/installcd-stage2-minimal-dist.spec
+++ b/releases/specs/sparc/sparc64/installcd-stage2-minimal-dist.spec
@@ -111,7 +111,6 @@ livecd/empty:
 	/usr/share/consoletrans
 	/usr/share/dict
 	/usr/share/doc
-	/usr/share/emacs
 	/usr/share/et
 	/usr/share/gcc-data
 	/usr/share/genkernel

--- a/releases/specs/sparc/sparc64/installcd-stage2-minimal.spec
+++ b/releases/specs/sparc/sparc64/installcd-stage2-minimal.spec
@@ -113,7 +113,6 @@ livecd/empty:
 	/usr/share/consoletrans
 	/usr/share/dict
 	/usr/share/doc
-	/usr/share/emacs
 	/usr/share/et
 	/usr/share/gcc-data
 	/usr/share/genkernel

--- a/releases/specs/x86/i486/installcd-stage2-minimal-openrc.spec
+++ b/releases/specs/x86/i486/installcd-stage2-minimal-openrc.spec
@@ -119,7 +119,6 @@ livecd/empty:
 	/usr/share/consoletrans
 	/usr/share/dict
 	/usr/share/doc
-	/usr/share/emacs
 	/usr/share/et
 	/usr/share/gcc-data
 	/usr/share/genkernel


### PR DESCRIPTION
emacs:

All live  media  incorrectly removes /usr/share/emacs which stops emacs from launched.

bcachefs:

Likely being dropped in the next LTS.

It was decided on IRC to drop this package rather than fix it
until the uncertainly around this filesystem is resolved.