### PR TITLE
Emu bootloader support

### DIFF
--- a/releases/specs-qemu/loong/installcd-stage1.spec
+++ b/releases/specs-qemu/loong/installcd-stage1.spec
@@ -59,6 +59,7 @@ livecd/packages:
 	net-wireless/iw
 	net-wireless/wireless-tools
 	net-wireless/wpa_supplicant
+	sys-boot/grub
 	sys-apps/arch-chroot
 	sys-apps/busybox
 	sys-apps/dmidecode

--- a/releases/specs-qemu/riscv/rv64_lp64d/installcd-stage1.spec
+++ b/releases/specs-qemu/riscv/rv64_lp64d/installcd-stage1.spec
@@ -60,6 +60,7 @@ livecd/packages:
 	net-wireless/iw
 	net-wireless/wireless-tools
 	net-wireless/wpa_supplicant
+	sys-boot/grub
 	sys-apps/arch-chroot
 	sys-apps/busybox
 	sys-apps/dmidecode

--- a/releases/specs-qemu/sparc/sparc64/installcd-stage1.spec
+++ b/releases/specs-qemu/sparc/sparc64/installcd-stage1.spec
@@ -57,6 +57,7 @@ livecd/packages:
 #	net-wireless/iw
 #	net-wireless/wireless-tools
 #	net-wireless/wpa_supplicant
+	sys-boot/grub
 	sys-apps/arch-chroot
 	sys-apps/busybox
 #	sys-apps/dmidecode


### PR DESCRIPTION
ISOs created via qemu-user now require GRUB
to be part of the stage1 package list.

This is because Catalyst now uses the chroot
to install the files needed to make the ISO
bootable from the host builder.