### PR TITLE
AMD64: Use 7zip

### DIFF
--- a/releases/specs/amd64/installcd-stage1.spec
+++ b/releases/specs/amd64/installcd-stage1.spec
@@ -31,7 +31,7 @@ livecd/packages:
 	app-arch/dpkg
 	app-arch/gzip
 	app-arch/mt-st
-	app-arch/p7zip
+	app-arch/7zip
 	app-arch/pbzip2
 	app-arch/tar
 	app-arch/unrar

--- a/releases/specs/amd64/livegui/livegui-stage1.spec
+++ b/releases/specs/amd64/livegui/livegui-stage1.spec
@@ -40,7 +40,7 @@ livecd/packages:
 	app-arch/deb2targz
 	app-arch/gzip
 	app-arch/mt-st
-	app-arch/p7zip
+	app-arch/7zip
 	app-arch/pbzip2
 	app-arch/rpm
 	app-arch/tar


### PR DESCRIPTION
As per https://gitweb.gentoo.org/repo/gentoo.git/commit/?id=c2f0f9e445bb7a5c2fa7a51b09d1a3759c409344

app-arch/p7zip is Outdated and replaced by app-arch/7zip. Many unfixed bugs including severe vulnerabilities.

Switching the live media to app-arch/7zip to match.